### PR TITLE
搜索api加上referer，以及更改默认UA

### DIFF
--- a/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/http/BiliHttpApi.kt
+++ b/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/http/BiliHttpApi.kt
@@ -119,7 +119,7 @@ object BiliHttpApi {
 
     private fun createClient() {
         client = HttpClient(OkHttp) {
-            BrowserUserAgent()
+            //BrowserUserAgent()
             install(ContentNegotiation) {
                 json(json)
             }
@@ -132,6 +132,7 @@ object BiliHttpApi {
             }
             install(JsoupPlugin)
             defaultRequest {
+                header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0")
                 url {
                     host = endPoint
                     protocol = URLProtocol.HTTPS
@@ -1222,6 +1223,7 @@ object BiliHttpApi {
         order?.let { parameter("order", it) }
         duration?.let { parameter("duration", it) }
         header("Cookie", "buvid3=$buvid3;")
+        header("referer", "https://www.bilibili.com")
     }.body()
 
     /** 获取番剧首页数据 */


### PR DESCRIPTION
加上referer只能降低触发风控的概率，只有修改掉默认ua才能彻底解决 #27 搜索触发风控的问题

~~另外搜索api其实还有一个问题，我不知道在哪里改，就是order排序web和app端默认排序totalrank是有关键词联想的，但是现在被锁死click按点击率排序没有关键词联想，会有一些问题，比如：“貔柴”，b站的关键词联想picai没有“貔柴”，只有“貔材”，而“貔材”按点击率排序结果为空，但是默认排序totalrank可以联想到“貔柴”~~