### PR TITLE
尝试解决视频详情页面崩溃问题

### DIFF
--- a/app/src/main/kotlin/dev/aaa1115910/bv/util/Extends.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/util/Extends.kt
@@ -139,7 +139,8 @@ fun Long.toMBString(): String = String.format("%.2f MB", this / 1024f / 1024f)
  * 改进的请求焦点的方法，失败后等待 100ms 后重试
  */
 fun FocusRequester.requestFocus(scope: CoroutineScope) {
-    scope.launch(Dispatchers.Default) {
+    // scope.launch(Dispatchers.Default) {
+    scope.launch( Dispatchers.Main) {
         runCatching {
             requestFocus()
         }.onFailure {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/video/VideoDetailViewModel.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/video/VideoDetailViewModel.kt
@@ -53,7 +53,15 @@ class VideoDetailViewModel(
                 aid = aid,
                 preferApiType = Prefs.apiType
             ).history
-            withContext(Dispatchers.Main) { videoDetail?.history = historyData }
+            // withContext(Dispatchers.Main) { videoDetail?.history = historyData }
+            // 切换到主线程来安全地更新状态
+            withContext(Dispatchers.Main) {
+                    // 使用 data class 的 copy() 方法创建一个新的 VideoDetail 实例，
+                    // 只更新其中的 history 字段，然后用这个新实例替换整个旧的状态。
+                videoDetail?.let { detail ->
+                    videoDetail = detail.copy(history = historyData)
+                }
+            }
         }.onFailure {
             logger.fInfo { "Load video av$aid only update history failed: ${it.stackTraceToString()}" }
         }.onSuccess {


### PR DESCRIPTION
之前视频详情页打开以后不知道怎么回事就会崩溃，不是常见现象无法稳定复现，这里尝试修复。
日志如下：
======== Device info ========
App Version: 0.3.7.r836.9568657.alpha (836)
Android Version: 9 (28)
Device: franklin
Model: HK1 BOX S905X3
Manufacturer: Amlogic
Brand: Amlogic
Product: franklin
Type: user
======== App Prefs ========
Login: true
Incognito Mode: false
Api Type: App
Default Resolution: R1080P
Default Codec: HEVC
Default Audio: A192K
Enabled Proxy: false
======== Logs ========
--------- beginning of crash
11-09 11:51:31.447 28132 28132 E AndroidRuntime: FATAL EXCEPTION: main
11-09 11:51:31.447 28132 28132 E AndroidRuntime: Process: dev.frost819.bv, PID: 28132
11-09 11:51:31.447 28132 28132 E AndroidRuntime: java.lang.IllegalArgumentException: Detected multithreaded access to SnapshotStateObserver: previousThreadId=15995), currentThread={id=2, name=main}. Note that observation on multiple threads in layout/draw is not supported. Make sure your measure/layout/draw for each Owner (AndroidComposeView) is executed on the same thread.
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at U.l0.a(SourceFile:3)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at e0.u.c(SourceFile:115)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at F0.v0.a(SourceFile:3)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at B.f.v(SourceFile:839)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at A.s.a(SourceFile:569)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at q0.c.c(SourceFile:51)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at q0.a.a(SourceFile:1423)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at q0.m.dispatchDraw(SourceFile:96)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.View.draw(View.java:20210)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19082)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.View.draw(View.java:19935)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewGroup.drawChild(ViewGroup.java:4334)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at r0.a.a(SourceFile:5)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at q0.i.R(SourceFile:19)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at q0.i.w(SourceFile:46)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at q0.c.e(SourceFile:57)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at G0.L0.h(SourceFile:105)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at G0.A.dispatchDraw(SourceFile:69)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.View.draw(View.java:20210)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19082)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4318)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4291)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19042)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4318)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4291)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19042)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4318)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4291)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19042)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4318)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4291)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19042)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ThreadedRenderer.updateViewTreeDisplayList(ThreadedRenderer.java:686)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ThreadedRenderer.updateRootDisplayList(ThreadedRenderer.java:692)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ThreadedRenderer.draw(ThreadedRenderer.java:801)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewRootImpl.draw(ViewRootImpl.java:3324)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:3128)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2487)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1464)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7196)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:949)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.Choreographer.doCallbacks(Choreographer.java:761)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.Choreographer.doFrame(Choreographer.java:696)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:935)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:873)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:193)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:6669)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
11-09 11:51:31.447 28132 28132 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: FATAL EXCEPTION: main
11-09 13:30:53.020 26462 26462 E AndroidRuntime: Process: dev.frost819.bv, PID: 26462
11-09 13:30:53.020 26462 26462 E AndroidRuntime: java.lang.IllegalArgumentException: Detected multithreaded access to SnapshotStateObserver: previousThreadId=16158), currentThread={id=2, name=main}. Note that observation on multiple threads in layout/draw is not supported. Make sure your measure/layout/draw for each Owner (AndroidComposeView) is executed on the same thread.
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at U.l0.a(SourceFile:3)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at e0.u.c(SourceFile:115)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at F0.v0.a(SourceFile:3)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at B.f.v(SourceFile:839)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at A.s.a(SourceFile:569)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at q0.c.c(SourceFile:51)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at q0.a.a(SourceFile:1423)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at q0.m.dispatchDraw(SourceFile:96)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.View.draw(View.java:20210)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19082)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.View.draw(View.java:19935)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewGroup.drawChild(ViewGroup.java:4334)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at r0.a.a(SourceFile:5)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at q0.i.R(SourceFile:19)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at q0.i.w(SourceFile:46)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at q0.c.e(SourceFile:57)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at G0.L0.h(SourceFile:105)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at G0.A.dispatchDraw(SourceFile:69)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.View.draw(View.java:20210)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19082)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4318)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4291)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19042)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4318)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4291)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19042)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4318)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4291)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19042)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:4318)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:4291)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19042)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ThreadedRenderer.updateViewTreeDisplayList(ThreadedRenderer.java:686)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ThreadedRenderer.updateRootDisplayList(ThreadedRenderer.java:692)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ThreadedRenderer.draw(ThreadedRenderer.java:801)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewRootImpl.draw(ViewRootImpl.java:3324)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:3128)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2487)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1464)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7196)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:949)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.Choreographer.doCallbacks(Choreographer.java:761)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.Choreographer.doFrame(Choreographer.java:696)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:935)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:873)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:193)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:6669)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
11-09 13:30:53.020 26462 26462 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
