### PR TITLE
可以查看所有参与投稿的up主

### DIFF
--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/CoAuthorsDialog.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/CoAuthorsDialog.kt
@@ -1,0 +1,253 @@
+package dev.aaa1115910.bv.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import kotlinx.coroutines.delay
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.layout.ContentScale
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import androidx.tv.material3.Border
+import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.tv.material3.Surface
+import coil.compose.AsyncImage
+import dev.aaa1115910.biliapi.entity.user.CoAuthor
+import dev.aaa1115910.bv.tv.component.TvAlertDialog
+
+@Stable
+class CoAuthorsDialogState internal constructor() {
+    var visible by mutableStateOf(false)
+        private set
+
+    var authors by mutableStateOf<List<CoAuthor>>(emptyList())
+        private set
+
+    fun open(input: List<CoAuthor>) {
+        val dedup = input.distinctBy { it.mid } // 稳定去重：保留第一次出现
+        authors = dedup
+        visible = dedup.size > 1
+    }
+
+    fun dismiss() {
+        visible = false
+    }
+}
+
+@Composable
+fun rememberCoAuthorsDialogState(): CoAuthorsDialogState = remember { CoAuthorsDialogState() }
+
+private data class CoAuthorGroup(
+    val title: String,
+    val members: List<CoAuthor>
+)
+
+private fun buildGroups(authors: List<CoAuthor>): List<CoAuthorGroup> {
+    // 稳定去重
+    val dedup = authors.distinctBy { it.mid }
+
+    // 按 title 稳定分组（保持 title 首次出现顺序）
+    val map = LinkedHashMap<String, MutableList<CoAuthor>>()
+    for (a in dedup) {
+        map.getOrPut(a.title) { mutableListOf() }.add(a)
+    }
+    val groups = map.entries.map { CoAuthorGroup(it.key, it.value) }.toMutableList()
+
+    // 投稿成员(UP主)分组置顶（title 原文显示）
+    val upIndex = groups.indexOfFirst { it.title == "UP主" }
+    if (upIndex > 0) {
+        val up = groups.removeAt(upIndex)
+        groups.add(0, up)
+    }
+    return groups
+}
+
+@Composable
+fun CoAuthorsDialogHost(
+    state: CoAuthorsDialogState,
+    onClickAuthor: (mid: Long, name: String) -> Unit,
+    modifier: Modifier = Modifier,
+    title: String = "联合投稿"
+) {
+    if (!state.visible) return
+
+    val groups = remember(state.authors) { buildGroups(state.authors) }
+
+    // 找到弹窗里第一个可聚焦成员（UP主组已在 buildGroups 里置顶）
+    val firstMemberMid = remember(groups) { groups.firstOrNull()?.members?.firstOrNull()?.mid }
+    val firstMemberFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(firstMemberMid) {
+        if (firstMemberMid == null) return@LaunchedEffect
+        // Dialog 刚弹出时直接 requestFocus 有概率失败，小延迟更稳
+        delay(60)
+        runCatching { firstMemberFocusRequester.requestFocus() }
+    }
+
+    TvAlertDialog(
+        onDismissRequest = { state.dismiss() },
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false
+        ),
+        title = { Text(text = title) },
+        text = {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
+                    .focusGroup(),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                items(groups, key = { it.title }) { group ->
+                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Text(
+                            text = group.title,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Color.White
+                        )
+                        LazyRow(
+                            contentPadding = PaddingValues(horizontal = 20.dp),
+                            horizontalArrangement = Arrangement.spacedBy(24.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            items(items = group.members, key = { it.mid }) { member ->
+                                val itemModifier =
+                                    if (member.mid == firstMemberMid) {
+                                        Modifier.focusRequester(firstMemberFocusRequester)
+                                    } else {
+                                        Modifier
+                                    }
+
+                                CoAuthorItem(
+                                    author = member,
+                                    modifier = itemModifier,
+                                    onClick = {
+                                        onClickAuthor(member.mid, member.name)
+                                        state.dismiss()
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun CoAuthorItem(
+    author: CoAuthor,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // 外层固定最大尺寸：保证“名字不动”
+    val outerSize = 86.dp
+    val idleInnerSize = 72.dp
+
+    var focused by remember { mutableStateOf(false) }
+    val innerSize by animateDpAsState(
+        targetValue = if (focused) outerSize else idleInnerSize,
+        label = "coAuthorAvatarSize"
+    )
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        // 名字贴着描边（避免看起来被描边挡住）
+        verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        Surface(
+            onClick = onClick,
+            modifier = Modifier
+                .size(outerSize)
+                .onFocusChanged { focused = it.isFocused },
+            shape = ClickableSurfaceDefaults.shape(shape = CircleShape),
+            // 透明背景
+            colors = ClickableSurfaceDefaults.colors(
+                containerColor = Color.Transparent,
+                focusedContainerColor = Color.Transparent,
+                pressedContainerColor = Color.Transparent
+            ),
+            border = ClickableSurfaceDefaults.border(
+                focusedBorder = Border(
+                    border = BorderStroke(3.dp, Color(0xFFFE7297)),
+                    shape = CircleShape
+                )
+            ),
+            scale = ClickableSurfaceDefaults.scale(focusedScale = 1f)
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                AsyncImage(
+                    modifier = Modifier
+                        .size(innerSize)
+                        .clip(CircleShape),
+                    model = author.face,
+                    contentDescription = author.name,
+                    contentScale = ContentScale.Crop
+                )
+            }
+        }
+
+        Text(
+            text = author.name,
+            color = Color.White,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+/**
+ * 给“up主页”按钮用的统一点击处理：
+ * - 单作者：直接跳转
+ * - 多作者：打开弹窗（由 state 管理）
+ */
+fun handleUpHomeClick(
+    authors: List<CoAuthor>,
+    state: CoAuthorsDialogState,
+    onNavigateSingle: (mid: Long, name: String) -> Unit
+) {
+    val dedup = authors.distinctBy { it.mid }
+    if (dedup.size <= 1) {
+        val only = dedup.firstOrNull() ?: return
+        onNavigateSingle(only.mid, only.name)
+    } else {
+        state.open(dedup)
+    }
+}

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/controllers/ControllerVideoInfo.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/controllers/ControllerVideoInfo.kt
@@ -83,7 +83,8 @@ fun ControllerVideoInfo(
     onShowRelatedVideos: () -> Unit,
     onGoToVideoInfo: () -> Unit,
     onToggleLoop: () -> Unit,
-    onGoToUpPage: () -> Unit
+    onGoToUpPage: () -> Unit,
+    hasMultipleCoAuthors: Boolean = false,
 ) {
     Box(
         modifier = modifier.fillMaxSize()
@@ -129,7 +130,8 @@ fun ControllerVideoInfo(
                 onShowRelatedVideos = onShowRelatedVideos,
                 onGoToVideoInfo = onGoToVideoInfo,
                 onToggleLoop = onToggleLoop,
-                onGoToUpPage = onGoToUpPage
+                onGoToUpPage = onGoToUpPage,
+                hasMultipleCoAuthors = hasMultipleCoAuthors,
             )
         }
     }
@@ -209,7 +211,8 @@ fun ControllerVideoInfoBottom(
     onShowRelatedVideos: () -> Unit,
     onGoToVideoInfo: () -> Unit,
     onToggleLoop: () -> Unit,
-    onGoToUpPage: () -> Unit
+    onGoToUpPage: () -> Unit,
+    hasMultipleCoAuthors: Boolean = false,
 ) {
     val seekFocusRequester = remember { FocusRequester() }
     val buttonsFocusRequester = remember { FocusRequester() }
@@ -319,7 +322,7 @@ fun ControllerVideoInfoBottom(
             ((if (danmakuEnabled) (R.drawable.danmaku_on_24px) else (R.drawable.danmaku_off_24px)) to "弹幕开关") to onDanmakuSwitchChange,
             (R.drawable.settings_24px to "打开设置") to onShowSettings,
             if (!fromSeason) (R.drawable.info_24px to "视频信息") to onGoToVideoInfo else null,
-            if (!fromSeason) (R.drawable.contact_page_24px to "up主页") to onGoToUpPage else null,
+            if (!fromSeason) ((if (hasMultipleCoAuthors) R.drawable.group_24px else R.drawable.contact_page_24px) to "up主页") to onGoToUpPage else null,
             if (!fromSeason)(R.drawable.related_videos_24px to "相关视频") to onShowRelatedVideos else null,
             ((if (isLooping) (R.drawable.repeat_one_on_24px) else (R.drawable.repeat_one_24px)) to "循环播放") to onToggleLoop,
         )

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/controllers/VideoPlayerController.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/controllers/VideoPlayerController.kt
@@ -379,7 +379,8 @@ fun VideoPlayerController(
                 )
             },
             onToggleLoop = onToggleLoop,
-            onGoToUpPage = onGoToUpPage
+            onGoToUpPage = onGoToUpPage,
+            hasMultipleCoAuthors = uiState.coAuthors.distinctBy { it.mid }.size > 1,
         )
 
         VideoListController(

--- a/app/src/main/kotlin/dev/aaa1115910/bv/repository/VideoInfoRepository.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/repository/VideoInfoRepository.kt
@@ -65,7 +65,8 @@ class VideoInfoRepository(private val videoDetailRepository: VideoDetailReposito
             pages = videoDetail.pages,
             relatedVideos = mapToVideoCardData(videoDetail.relatedVideos),
             ugcSeason = videoDetail.ugcSeason,
-        )
+        coAuthors = videoDetail.coAuthors,
+            )
 
         _videoDetailState.update { videoDetailState }
     }

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoInfoScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoInfoScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -37,6 +38,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Done
+import androidx.compose.material.icons.rounded.Group
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.ViewModule
 import androidx.compose.material.icons.rounded.Warning
@@ -64,6 +66,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
@@ -104,6 +107,8 @@ import dev.aaa1115910.bv.component.buttons.FavoriteButton
 import dev.aaa1115910.bv.component.buttons.LikeButton
 import dev.aaa1115910.bv.component.ifElse
 import dev.aaa1115910.bv.component.videocard.VideosRow
+import dev.aaa1115910.bv.component.CoAuthorsDialogHost
+import dev.aaa1115910.bv.component.rememberCoAuthorsDialogState
 import dev.aaa1115910.bv.entity.VideoListItem
 import dev.aaa1115910.bv.entity.proxy.ProxyArea
 import dev.aaa1115910.bv.ui.effect.UiEffect
@@ -498,7 +503,9 @@ fun VideoInfoData(
     onSendVideoOneClickTripleAction: () -> Unit
 ) {
     val localDensity = LocalDensity.current
-    var heightIs by remember { mutableStateOf(0.dp) }
+    val context = LocalContext.current
+        val coAuthorsDialogState = rememberCoAuthorsDialogState()
+        var heightIs by remember { mutableStateOf(0.dp) }
 
     Row(
         modifier = modifier
@@ -569,15 +576,58 @@ fun VideoInfoData(
                     }
                 }
                 Row(
-                    verticalAlignment = Alignment.CenterVertically
+                    modifier = Modifier.height(IntrinsicSize.Min),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
-                    UpButton(
-                        name = videoDetail.author.name,
-                        followed = isFollowing,
-                        onClickUp = onClickUp,
-                        onAddFollow = onAddFollow,
-                        onDelFollow = onDelFollow
-                    )
+                    val coAuthorCount = remember(videoDetail.coAuthors) {
+                        videoDetail.coAuthors.distinctBy { it.mid }.size
+                    }
+                    var upButtonHeightPx by remember { mutableIntStateOf(0) }
+                    val density = LocalDensity.current
+                    val fallbackSize = 6.dp
+                    val squareSize = remember(upButtonHeightPx, density) {
+                        if (upButtonHeightPx > 0) with(density) { upButtonHeightPx.toDp() } else fallbackSize
+                    }
+                    if (coAuthorCount > 1) {
+                        Surface(
+                            modifier = Modifier.size(squareSize)
+                                .aspectRatio(1f),
+                            onClick = { coAuthorsDialogState.open(videoDetail.coAuthors) },
+                            shape = ClickableSurfaceDefaults.shape(shape = MaterialTheme.shapes.small),
+                            colors = ClickableSurfaceDefaults.colors(
+                                containerColor = Color.White.copy(alpha = 0.2f),
+                                focusedContainerColor = Color.White.copy(alpha = 0.2f),
+                                pressedContainerColor = Color.White.copy(alpha = 0.2f)
+                            ),
+                            scale = ClickableSurfaceDefaults.scale(focusedScale = 1f),
+                            border = ClickableSurfaceDefaults.border(
+                                focusedBorder = Border(
+                                    border = BorderStroke(width = 3.dp, color = Color.White),
+                                    shape = MaterialTheme.shapes.small
+                                )
+                            )
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.Group,
+                                contentDescription = "联合投稿",
+                                tint = Color.White,
+                                modifier = Modifier.padding(3.dp)
+                            )
+                        }
+                    }
+
+                    Box(
+                        modifier = Modifier.onSizeChanged { upButtonHeightPx = it.height }
+                    ) {
+                        UpButton(
+                            name = videoDetail.author.name,
+                            followed = isFollowing,
+                            onClickUp = onClickUp,
+                            onAddFollow = onAddFollow,
+                            onDelFollow = onDelFollow
+                        )
+                    }
                 }
             }
             Row(
@@ -618,8 +668,14 @@ fun VideoInfoData(
                     }
                 }
             }
-        }
-    }
+
+    CoAuthorsDialogHost(
+                    state = coAuthorsDialogState,
+                    onClickAuthor = { mid, name ->
+                        UpInfoActivity.actionStart(context, mid = mid, name = name)
+                    }
+                )
+            }}
 }
 
 @Composable

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoPlayerV3Screen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoPlayerV3Screen.kt
@@ -25,6 +25,9 @@ import dev.aaa1115910.bv.component.DanmakuPlayerCompose
 import dev.aaa1115910.bv.component.controllers.VideoPlayerController
 import dev.aaa1115910.bv.component.controllers.VideoProgressSeek
 import dev.aaa1115910.bv.component.ifElse
+import dev.aaa1115910.bv.component.CoAuthorsDialogHost
+import dev.aaa1115910.bv.component.handleUpHomeClick
+import dev.aaa1115910.bv.component.rememberCoAuthorsDialogState
 import dev.aaa1115910.bv.entity.VideoAspectRatio
 import dev.aaa1115910.bv.entity.VideoListItem
 import dev.aaa1115910.bv.entity.proxy.ProxyArea
@@ -50,6 +53,9 @@ fun VideoPlayerV3Screen(
     val logger = KotlinLogging.logger { }
     val context = LocalContext.current
     val videoPlayer = playerViewModel.videoPlayer!!
+
+    val coAuthorsDialogState = rememberCoAuthorsDialogState()
+    var lastCoAuthorsDialogVisible by remember { mutableStateOf(false) }
 
     val maskFinder = remember { DanmakuMaskFinder() }
     var currentDanmakuMaskFrame: DanmakuMaskFrame? by remember { mutableStateOf(null) }
@@ -85,6 +91,14 @@ fun VideoPlayerV3Screen(
             // 周期延迟
             delay(15000)
         }
+    }
+
+    LaunchedEffect(coAuthorsDialogState.visible) {
+        val now = coAuthorsDialogState.visible
+        if (!now && lastCoAuthorsDialogVisible) {
+            videoPlayer.start()
+        }
+        lastCoAuthorsDialogVisible = now
     }
 
     // 弹幕防遮挡蒙版更新
@@ -161,10 +175,24 @@ fun VideoPlayerV3Screen(
             isLooping = !isLooping
         },
         onGoToUpPage = {
-            UpInfoActivity.actionStart(
-                context,
-                mid = uiState.authorMid,
-                name = uiState.authorName
+            val dedup = uiState.coAuthors.distinctBy { it.mid }
+
+            // 多作者：打开弹窗前立刻暂停
+            if (dedup.size > 1) {
+                videoPlayer.pause()
+                playerViewModel.trySendHeartbeat()
+            }
+
+            handleUpHomeClick(
+                authors = uiState.coAuthors,
+                state = coAuthorsDialogState,
+                onNavigateSingle = { mid, name ->
+                    UpInfoActivity.actionStart(
+                        context,
+                        mid = mid,
+                        name = name
+                    )
+                }
             )
         },
 
@@ -255,4 +283,11 @@ fun VideoPlayerV3Screen(
             }
         }
     }
+
+    CoAuthorsDialogHost(
+        state = coAuthorsDialogState,
+        onClickAuthor = { mid, name ->
+            UpInfoActivity.actionStart(context, mid = mid, name = name)
+        }
+    )
 }

--- a/app/src/main/kotlin/dev/aaa1115910/bv/ui/state/PlayerUiState.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/ui/state/PlayerUiState.kt
@@ -27,6 +27,7 @@ data class PlayerUiState(
     val seasonId: Int = 0,
     val authorMid: Long = 0,
     val authorName: String = "",
+    val coAuthors: List<dev.aaa1115910.biliapi.entity.user.CoAuthor> = emptyList(),
     val title: String = "",
     val videoHeight: Int = 0,
     val videoWidth: Int = 0,

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
@@ -190,7 +190,10 @@ class VideoPlayerV3ViewModel(
                 if (newDetail == null) return@onEach
 
                 _uiState.update { currentState ->
-                    currentState.copy(relatedVideos = newDetail.relatedVideos)
+                    currentState.copy(
+                        relatedVideos = newDetail.relatedVideos,
+                        coAuthors = newDetail.coAuthors
+                    )
                 }
                 logger.fInfo { "Sync related videos from repo" }
             }

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/video/VideoDetailUiState.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/video/VideoDetailUiState.kt
@@ -49,4 +49,5 @@ data class VideoDetailState(
     val isLiked: Boolean,
     val isCoined: Boolean,
     val isFavorite: Boolean,
+    val coAuthors: List<dev.aaa1115910.biliapi.entity.user.CoAuthor> = emptyList(),
 )

--- a/app/src/main/res/drawable/group_24px.xml
+++ b/app/src/main/res/drawable/group_24px.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16,11c1.66,0 2.99,-1.34 2.99,-3S17.66,5 16,5s-3,1.34 -3,3 1.34,3 3,3zM8,11c1.66,0 2.99,-1.34 2.99,-3S9.66,5 8,5 5,6.34 5,8s1.34,3 3,3zM8,13c-2.33,0 -7,1.17 -7,3.5L1,18c0,0.55 0.45,1 1,1h12c0.55,0 1,-0.45 1,-1v-1.5c0,-2.33 -4.67,-3.5 -7,-3.5zM16,13c-0.29,0 -0.62,0.02 -0.97,0.05 0.02,0.01 0.03,0.03 0.04,0.04 1.14,0.83 1.93,1.94 1.93,3.41L17,18c0,0.35 -0.07,0.69 -0.18,1L22,19c0.55,0 1,-0.45 1,-1v-1.5c0,-2.33 -4.67,-3.5 -7,-3.5z"/>
+</vector>

--- a/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/entity/user/CoAuthor.kt
+++ b/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/entity/user/CoAuthor.kt
@@ -1,0 +1,16 @@
+package dev.aaa1115910.biliapi.entity.user
+
+/**
+ * 联合投稿成员（用于 UGC staff）
+ *
+ * @param mid 成员 mid
+ * @param name 昵称
+ * @param face 头像
+ * @param title 职务/角色（直接显示后端原始字符串，如 UP主/协力/...）
+ */
+data class CoAuthor(
+    val mid: Long,
+    val name: String,
+    val face: String,
+    val title: String
+)

--- a/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/entity/video/VideoDetail.kt
+++ b/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/entity/video/VideoDetail.kt
@@ -28,11 +28,30 @@ data class VideoDetail(
     val userActions: UserActions,
     val history: History,
     val playerIcon: PlayerIcon? = null,
-    val isUpowerExclusive: Boolean = false
+    val isUpowerExclusive: Boolean = false,
+    val coAuthors: List<dev.aaa1115910.biliapi.entity.user.CoAuthor> = emptyList()
 ) {
     companion object {
         fun fromViewReply(viewReply: ViewReply): VideoDetail {
             if (!viewReply.hasActivitySeason()) {
+                val staff = viewReply.staffList.map {
+                    dev.aaa1115910.biliapi.entity.user.CoAuthor(
+                        mid = it.mid,
+                        name = it.name,
+                        face = it.face,
+                        title = it.title
+                    )
+                }
+                val owner = viewReply.arc.author
+                val coAuthors = reorderUpGroupFirst(
+                    mergeOwnerIntoStaffFirst(
+                        ownerMid = owner.mid,
+                        ownerName = owner.name,
+                        ownerFace = owner.face,
+                        staff = staff
+                    )
+                )
+
                 return VideoDetail(
                     bvid = viewReply.bvid,
                     aid = viewReply.arc.aid,
@@ -54,9 +73,28 @@ data class VideoDetail(
                     tags = viewReply.tagList.map { Tag.fromTag(it) },
                     userActions = UserActions.fromReqUser(viewReply.reqUser),
                     history = History.fromHistory(viewReply.history),
-                    playerIcon = viewReply.playerIcon?.let { PlayerIcon.fromPlayerIcon(it) }
+                    playerIcon = viewReply.playerIcon?.let { PlayerIcon.fromPlayerIcon(it) },
+                    coAuthors = coAuthors
                 )
             } else {
+                val staff = viewReply.activitySeason.staffList.map {
+                    dev.aaa1115910.biliapi.entity.user.CoAuthor(
+                        mid = it.mid,
+                        name = it.name,
+                        face = it.face,
+                        title = it.title
+                    )
+                }
+                val owner = viewReply.activitySeason.arc.author
+                val coAuthors = reorderUpGroupFirst(
+                    mergeOwnerIntoStaffFirst(
+                        ownerMid = owner.mid,
+                        ownerName = owner.name,
+                        ownerFace = owner.face,
+                        staff = staff
+                    )
+                )
+
                 return VideoDetail(
                     bvid = viewReply.activitySeason.bvid,
                     aid = viewReply.activitySeason.arc.aid,
@@ -86,12 +124,31 @@ data class VideoDetail(
                         PlayerIcon.fromPlayerIcon(
                             it
                         )
-                    }
+                    },
+                    coAuthors = coAuthors
                 )
             }
         }
 
-        fun fromVideoDetail(videoDetail: dev.aaa1115910.biliapi.http.entity.video.VideoDetail) =
+        fun fromVideoDetail(videoDetail: dev.aaa1115910.biliapi.http.entity.video.VideoDetail) = run {
+            val owner = videoDetail.view.owner
+            val staff = videoDetail.view.staff.map {
+                dev.aaa1115910.biliapi.entity.user.CoAuthor(
+                    mid = it.mid,
+                    name = it.name,
+                    face = it.face,
+                    title = it.title
+                )
+            }
+            val coAuthors = reorderUpGroupFirst(
+                mergeOwnerIntoStaffFirst(
+                    ownerMid = owner.mid,
+                    ownerName = owner.name,
+                    ownerFace = owner.face,
+                    staff = staff
+                )
+            )
+
             VideoDetail(
                 bvid = videoDetail.view.bvid,
                 aid = videoDetail.view.aid,
@@ -113,8 +170,46 @@ data class VideoDetail(
                 userActions = UserActions(),
                 history = History(0, 0),
                 playerIcon = null,
-                isUpowerExclusive = videoDetail.view.isUpowerExclusive?: false
+                isUpowerExclusive = videoDetail.view.isUpowerExclusive?: false,
+                coAuthors = coAuthors
             )
+        }
+
+        private fun mergeOwnerIntoStaffFirst(
+            ownerMid: Long,
+            ownerName: String,
+            ownerFace: String,
+            staff: List<dev.aaa1115910.biliapi.entity.user.CoAuthor>
+        ): List<dev.aaa1115910.biliapi.entity.user.CoAuthor> {
+            val ownerAsCoAuthor = dev.aaa1115910.biliapi.entity.user.CoAuthor(
+                mid = ownerMid,
+                name = ownerName,
+                face = ownerFace,
+                title = "UP主"
+            )
+
+            // staff 为空：兜底只显示 UP主
+            val merged = if (staff.isEmpty()) {
+                listOf(ownerAsCoAuthor)
+            } else {
+                // staff 不含 owner：把 UP主 补到最前面，保证“投稿成员”在顶部
+                if (staff.any { it.mid == ownerMid }) staff else listOf(ownerAsCoAuthor) + staff
+            }
+
+            // 稳定去重：保留第一次出现的条目
+            return merged.distinctBy { it.mid }
+        }
+
+        private fun reorderUpGroupFirst(list: List<dev.aaa1115910.biliapi.entity.user.CoAuthor>): List<dev.aaa1115910.biliapi.entity.user.CoAuthor> {
+            // 如果存在 title=="UP主" 的条目，尽量让它在前面。
+            // 最终弹窗分组排序仍在 UI 层做（确保 title=="UP主" 组排第一）。
+            val idx = list.indexOfFirst { it.title == "UP主" }
+            if (idx <= 0) return list
+            val mutable = list.toMutableList()
+            val item = mutable.removeAt(idx)
+            mutable.add(0, item)
+            return mutable
+        }
     }
 
     data class Stat(


### PR DESCRIPTION
如题，详情页面和播放器都能看，
如果是多人合作视频，详情页upbutton左边会显示一个方形小按钮，点开就能看到所有参与的up主；
播放器个人主页也会打开一个面板，能看到所有参与的up主。
点击up的头像可以进入他们的个人空间