### PR TITLE
解决切换activity或切换后台再切回来导致播放器抽风的问题

### DIFF
--- a/app/src/main/kotlin/dev/aaa1115910/bv/activities/video/VideoPlayerV3Activity.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/activities/video/VideoPlayerV3Activity.kt
@@ -84,20 +84,19 @@ class VideoPlayerV3Activity : ComponentActivity() {
     }
 
     override fun onStart() {
-        super.onStart()
-
-        // 回到前台：先进入抑制期，避免 attach surface 阶段闪抽风
+        // 先进入抑制期，再走 super，覆盖 Lifecycle.ON_START 期间可能发生的 surface 相关竞态
         playerViewModel.setSuppressPlayerErrors(true)
         Log.i("BugDebug", "VideoPlayerV3Activity onStart: suppressPlayerErrors=true (resuming)")
+
+        super.onStart()
 
         // 快恢复（不重建）或按需重建
         playerViewModel.onHostStartFastResumeOrRecreate()
 
         lifecycleScope.launch {
             delay(500)
-            // 只有当页面还在前台时才恢复
-            if (lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.STARTED)) {
-                // 退出抑制期
+            // 仅当页面已真正回到可交互前台时才退出抑制
+            if (lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.RESUMED)) {
                 playerViewModel.setSuppressPlayerErrors(false)
                 Log.i("BugDebug", "VideoPlayerV3Activity onStart: suppressPlayerErrors=false")
             }
@@ -129,11 +128,11 @@ class VideoPlayerV3Activity : ComponentActivity() {
     }
 
     override fun onPause() {
-        super.onPause()
-
-        // 进入后台/跳转别的 Activity 前：抑制 stop/surfaceDestroyed 期间的 surface-detach 类错误进入 UI
+        // 先进入抑制期，再走 super，覆盖 Lifecycle.ON_PAUSE 期间的 surface detach 竞态
         playerViewModel.setSuppressPlayerErrors(true)
         Log.i("BugDebug", "VideoPlayerV3Activity onPause: suppressPlayerErrors=true")
+
+        super.onPause()
 
         // 恢复状态栏
         WindowInsetsControllerCompat(window, window.decorView)

--- a/app/src/main/kotlin/dev/aaa1115910/bv/activities/video/VideoPlayerV3Activity.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/activities/video/VideoPlayerV3Activity.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
+import android.util.Log
+import androidx.lifecycle.lifecycleScope
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
@@ -22,6 +24,8 @@ import dev.aaa1115910.bv.util.Prefs
 import dev.aaa1115910.bv.util.fInfo
 import dev.aaa1115910.bv.viewmodel.player.VideoPlayerV3ViewModel
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class VideoPlayerV3Activity : ComponentActivity() {
@@ -78,6 +82,27 @@ class VideoPlayerV3Activity : ComponentActivity() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+
+        // 回到前台：先进入抑制期，避免 attach surface 阶段闪抽风
+        playerViewModel.setSuppressPlayerErrors(true)
+        Log.i("BugDebug", "VideoPlayerV3Activity onStart: suppressPlayerErrors=true (resuming)")
+
+        // 快恢复（不重建）或按需重建
+        playerViewModel.onHostStartFastResumeOrRecreate()
+
+        lifecycleScope.launch {
+            delay(500)
+            // 只有当页面还在前台时才恢复
+            if (lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.STARTED)) {
+                // 退出抑制期
+                playerViewModel.setSuppressPlayerErrors(false)
+                Log.i("BugDebug", "VideoPlayerV3Activity onStart: suppressPlayerErrors=false")
+            }
+        }
+    }
+
     override fun onResume() {
         super.onResume()
 
@@ -105,12 +130,30 @@ class VideoPlayerV3Activity : ComponentActivity() {
     override fun onPause() {
         super.onPause()
 
+        // 进入后台/跳转别的 Activity 前：抑制 stop/surfaceDestroyed 期间的 surface-detach 类错误进入 UI
+        playerViewModel.setSuppressPlayerErrors(true)
+        Log.i("BugDebug", "VideoPlayerV3Activity onPause: suppressPlayerErrors=true")
+
         // 恢复状态栏
         WindowInsetsControllerCompat(window, window.decorView)
             .show(WindowInsetsCompat.Type.systemBars())
 
         playerViewModel.videoPlayer?.pause()
         playerViewModel.danmakuPlayer?.pause()
+    }
+
+    override fun onStop() {
+        // 尽量早做，避免 stop 阶段 surfaceDestroyed 触发后再处理
+        Log.i("BugDebug", "VideoPlayerV3Activity onStop: isFinishing=$isFinishing")
+
+        if (!isFinishing) {
+            playerViewModel.onHostStopFastResume()
+        } else {
+            // 退出 Activity 时也抑制错误，避免“退出前闪抽风”
+            playerViewModel.setSuppressPlayerErrors(true)
+        }
+
+        super.onStop()
     }
 
     private fun initVideoPlayer() {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/activities/video/VideoPlayerV3Activity.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/activities/video/VideoPlayerV3Activity.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import android.util.Log
 import dev.aaa1115910.biliapi.entity.ApiType
 import dev.aaa1115910.biliapi.entity.user.Author
 import dev.aaa1115910.bv.R

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoPlayerV3Screen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoPlayerV3Screen.kt
@@ -62,6 +62,7 @@ fun VideoPlayerV3Screen(
         playerViewModel.uiEffect.collect { effect ->
             when (effect) {
                 PlayerUiEffect.FinishActivity -> {
+                    playerViewModel.setSuppressPlayerErrors(true)
                     (context as Activity).finish()
                 }
 
@@ -144,6 +145,7 @@ fun VideoPlayerV3Screen(
             playerViewModel.trySendHeartbeat()
         },
         onExit = {
+            playerViewModel.setSuppressPlayerErrors(true)
             (context as Activity).finish()
         },
         onGoTime = { time ->

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
@@ -2,6 +2,8 @@ package dev.aaa1115910.bv.viewmodel.player
 
 import android.net.Uri
 import android.util.Log
+import android.os.Build
+import java.util.concurrent.atomic.AtomicBoolean
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -80,6 +82,22 @@ import java.net.URI
 import java.util.Calendar
 import kotlin.coroutines.cancellation.CancellationException
 
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+private fun media3Slashy(): String = androidx.media3.common.MediaLibraryInfo.VERSION_SLASHY
+
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+private fun hasDetachSurfaceTimeout(t: Throwable?): Boolean {
+    var cur: Throwable? = t
+    while (cur != null) {
+        if (cur is androidx.media3.exoplayer.ExoTimeoutException &&
+            cur.timeoutOperation ==
+            androidx.media3.exoplayer.ExoTimeoutException.TIMEOUT_OPERATION_DETACH_SURFACE
+        ) return true
+        cur = cur.cause
+    }
+    return false
+}
+
 @KoinViewModel
 
 class VideoPlayerV3ViewModel(
@@ -94,6 +112,23 @@ class VideoPlayerV3ViewModel(
         private set
 
     private var playData: PlayData? = null
+    @Volatile
+    private var suppressPlayerErrors: Boolean = false
+    @Volatile
+    private var needRecreateOnStart: Boolean = false
+    // 用于断点续播（毫秒）
+    private var pendingResumePositionMs: Long = 0L
+    // 防止 onStart 反复触发导致重复重建/prepare
+    private val recreateInProgress = AtomicBoolean(false)
+    // 快恢复开关：true=切后台只 pause，不 release；false=保持“每次 onStop 都 release 重建”
+    @Volatile
+    private var fastResumeEnabled: Boolean = true
+    // 一旦命中 surface/codec 输出相关异常，就认为当前 ExoPlayer 出问题，下次回场必须重建
+    @Volatile
+    private var surfaceBugDetected: Boolean = false
+    // 仅首次打印环境信息（设备 + Media3 版本）
+    @Volatile
+    private var envLogged: Boolean = false
     private val typeFilter = TypeFilter()
     private var danmakuConfig = DanmakuConfig()
 
@@ -114,6 +149,32 @@ class VideoPlayerV3ViewModel(
 
     private val videoPlayerListener = object : VideoPlayerListener {
         override fun onError(error: Exception) {
+            // 抑制期：stop/surfaceDestroyed/回场 attach 阶段的 surface 类错误不进 UI，避免“进/退页面闪抽风”
+            if (suppressPlayerErrors) {
+                val isDetachTimeoutByType = hasDetachSurfaceTimeout(error)
+
+                // 字符串兜底（避免厂商/版本差异导致类型判断漏判）
+                val msg = if (!isDetachTimeoutByType) error.message.orEmpty() else ""
+                val st = if (!isDetachTimeoutByType) error.stackTraceToString() else ""
+
+                val isSurfaceDetachError =
+                    isDetachTimeoutByType ||
+                            msg.contains("Detaching surface timed out", ignoreCase = true) ||
+                            st.contains("Detaching surface timed out", ignoreCase = true) ||
+                            st.contains("native_setSurface", ignoreCase = true) ||
+                            st.contains("setOutputSurface", ignoreCase = true)
+
+                if (isSurfaceDetachError) {
+                    // 命中该类错误，就认为当前 ExoPlayer 可能已出问题，下次回场必须重建
+                    surfaceBugDetected = true
+                    needRecreateOnStart = true
+
+                    Log.e("BugDebug", "ViewModel onError suppressed (surface bug): ${error.message}", error)
+                    return
+                }
+            }
+
+            Log.e("BugDebug", "ViewModel onError -> PlayerState.Error", error)
             logger.info { "onError: $error" }
             _uiState.update {
                 it.copy(
@@ -291,6 +352,190 @@ class VideoPlayerV3ViewModel(
 
         videoPlayer?.release()
         videoPlayer = null
+    }
+
+    fun setSuppressPlayerErrors(suppress: Boolean) {
+        suppressPlayerErrors = suppress
+        Log.i("BugDebug", "ViewModel setSuppressPlayerErrors=$suppress")
+    }
+
+    /**
+     * Host(Activity) stop 时调用：
+     * - 记录断点（ms）
+     * - 标记下次 start 要重建
+     * - 释放旧 ExoPlayer（这台真机上 old 实例常已不可恢复）
+     */
+    fun onHostStopReleaseForRecreate() {
+        val player = videoPlayer
+        val pos = player?.currentPosition ?: 0L
+        pendingResumePositionMs = pos.coerceAtLeast(0L)
+        needRecreateOnStart = true
+
+        // 复用seekToLastPlayed 机制（单位：秒）
+        val resumeSec = (pendingResumePositionMs / 1000L).toInt().coerceAtLeast(0)
+        _uiState.update { it.copy(lastPlayed = resumeSec) }
+
+        Log.i(
+            "BugDebug",
+            "ViewModel onHostStopReleaseForRecreate: posMs=$pendingResumePositionMs resumeSec=$resumeSec"
+        )
+
+        // 尽量先“解绑视频输出”再 release，减少厂商 codec/surface bug 触发概率
+        runCatching {
+            // 没有 PlayerView 引用时，也可以让 ExoPlayer 尽量清掉 video output
+            (player as? dev.aaa1115910.bv.player.impl.exo.ExoMediaPlayer)
+                ?.mPlayer
+                ?.clearVideoSurface()
+        }
+
+        // 释放坏掉的 ExoPlayer。这里不把 videoPlayer 置 null，避免 Compose 侧使用 !! 直接 NPE。
+        runCatching { player?.release() }
+            .onFailure { Log.e("BugDebug", "ViewModel: release() failed", it) }
+    }
+
+    /**
+     * Host(Activity) start 时调用：如需则重建 ExoPlayer 并自动续播。
+     */
+    fun onHostStartRecreateAndAutoPlayIfNeeded() {
+        if (!needRecreateOnStart) return
+        // 幂等/防并发（onStart 可能被重复触发）
+        if (!recreateInProgress.compareAndSet(false, true)) {
+            Log.w("BugDebug", "ViewModel onHostStart: recreate already in progress, skip")
+            return
+        }
+
+        needRecreateOnStart = false
+
+        try {
+            val player = videoPlayer
+            if (player == null) {
+                Log.e("BugDebug", "ViewModel onHostStart: videoPlayer is null (unexpected)")
+                return
+            }
+
+            Log.i("BugDebug", "ViewModel onHostStart: recreate player and auto play")
+
+            // 重建 ExoPlayer
+            runCatching { player.initPlayer() }
+                .onFailure {
+                    Log.e("BugDebug", "ViewModel: initPlayer() failed", it)
+                    _uiState.update { s ->
+                        s.copy(
+                            playerState = PlayerState.Error(
+                                it.message ?: "initPlayer failed"
+                            )
+                        )
+                    }
+                    return
+                }
+
+            // 仅首次打印环境信息（设备 + Media3 版本）
+            if (!envLogged) {
+                envLogged = true
+                Log.i(
+                    "BugDebug",
+                    "Env: MANUFACTURER=${Build.MANUFACTURER}, MODEL=${Build.MODEL}, SDK=${Build.VERSION.SDK_INT}," +
+                            "Media3=${media3Slashy()}," + "softDecode=${Prefs.enableSoftwareVideoDecoder}"
+                )
+            }
+
+            // 重新 prepare 播放源：优先复用已加载的 playData（避免再次请求）
+            //    playQuality() 是 ViewModel 内 private，可直接调用。
+            if (playData != null) {
+                runCatching {
+                    playQuality(
+                        qn = _uiState.value.mediaProfileState.qualityId,
+                        codec = _uiState.value.mediaProfileState.videoCodec,
+                        audio = _uiState.value.mediaProfileState.audio
+                    )
+                    // 手动恢复到暂停时的进度条
+                    if (pendingResumePositionMs > 0) {
+                        player.seekTo(pendingResumePositionMs)
+                        // 清空 UI 状态里的 lastPlayed，防止 onPlay 再次触发跳转提示
+                        _uiState.update { it.copy(lastPlayed = 0) }
+                    }
+                    player.setOptions() // playWhenReady=true
+                    player.start()      // 自动播放
+                }.onFailure {
+                    Log.e("BugDebug", "ViewModel: replay with cached playData failed", it)
+                    _uiState.update { s ->
+                        s.copy(
+                            playerState = PlayerState.Error(
+                                it.message ?: "replay failed"
+                            )
+                        )
+                    }
+                }
+            } else {
+                // 没有 playData 时重新拉取（会走你现有 loadPlayUrlImpl 流程）
+                // setOptions 先开，确保准备好后自动播放。
+                player.setOptions()
+
+                val st = _uiState.value
+                Log.w("BugDebug", "ViewModel: playData is null, fallback to loadPlayUrl")
+                loadPlayUrl(
+                    avid = st.aid,
+                    cid = st.cid,
+                    epid = st.epid,
+                    title = st.title
+                )
+            }
+        } finally {
+            recreateInProgress.set(false)
+        }
+    }
+
+    /**
+     * Host(Activity) stop 时调用（快路径）：
+     * - 默认只 pause，不 release（秒回）
+     * - 如果检测到 surfaceBugDetected，则回退到“release + 下次重建”
+     */
+    fun onHostStopFastResume() {
+        val player = videoPlayer ?: return
+
+        // 记录断点（ms）；用于兜底重建时 seek
+        pendingResumePositionMs = player.currentPosition.coerceAtLeast(0L)
+        val resumeSec = (pendingResumePositionMs / 1000L).toInt().coerceAtLeast(0)
+        _uiState.update { it.copy(lastPlayed = resumeSec) }
+
+        Log.i(
+            "BugDebug",
+            "ViewModel onHostStopFastResume: fast=$fastResumeEnabled surfaceBugDetected=$surfaceBugDetected posMs=$pendingResumePositionMs"
+        )
+
+        // 无论快慢策略，先暂停，避免后台继续播放
+        runCatching { player.pause() }
+
+        // 慢但稳：（每次 stop 都 release）
+        if (!fastResumeEnabled) {
+            onHostStopReleaseForRecreate()
+            return
+        }
+
+        // 快但可能翻车：只有检测到 surface/codec 输出 bug 时才回退到 release+重建
+        if (surfaceBugDetected) {
+            onHostStopReleaseForRecreate()
+        }
+    }
+
+    /**
+     * Host(Activity) start 时调用：
+     * - 若 needRecreateOnStart=true：“重建 + playQuality/prepare + 自动续播”
+     * - 否则：直接 start（秒回，不重建，不重新 prepare）
+     */
+    fun onHostStartFastResumeOrRecreate() {
+        if (needRecreateOnStart) {
+            Log.i("BugDebug", "ViewModel onHostStartFastResumeOrRecreate: recreate")
+            // 重建成功后把 surfaceBugDetected 清掉（否则会一直走慢路径）
+            onHostStartRecreateAndAutoPlayIfNeeded()
+            surfaceBugDetected = false
+            return
+        }
+
+        if (!fastResumeEnabled) return
+
+        Log.i("BugDebug", "ViewModel onHostStartFastResumeOrRecreate: fast resume")
+        runCatching { videoPlayer?.start() }
     }
 
     fun initDanmakuPlayer() {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
@@ -127,18 +127,6 @@ class VideoPlayerV3ViewModel(
     @Volatile
     private var surfaceBugDetected: Boolean = false
 
-    @Volatile
-    private var suppressPlayerErrors: Boolean = false
-
-    @Volatile
-    private var needRecreateOnStart: Boolean = false
-
-    // 用于断点续播（毫秒）
-    private var pendingResumePositionMs: Long = 0L
-
-    // 防止 onStart 反复触发导致重复重建/prepare
-    private val recreateInProgress = AtomicBoolean(false)
-
     // 仅首次打印环境信息（设备 + Media3 版本），便于你贴 Logcat 排查
     @Volatile
     private var envLogged: Boolean = false
@@ -491,7 +479,6 @@ class VideoPlayerV3ViewModel(
                     avid = st.aid,
                     cid = st.cid,
                     epid = st.epid,
-                    title = st.title
                 )
             }
         } finally {
@@ -1126,10 +1113,9 @@ class VideoPlayerV3ViewModel(
             ?: playData!!.flac.takeIf { it?.codecId == targetAudio.code }
             ?: playData!!.dashAudios.minByOrNull { it.codecId }
 
-        // App 播放源可能返回空的 dashAudios（此时允许仅播放视频，避免 first() 触发 List is empty）
-        var audioUrl: String? = audioItem?.baseUrl
-        val audioUrls = mutableListOf<String>()
-        audioItem?.baseUrl?.let { audioUrls.add(it) }
+        var audioUrl = audioItem?.baseUrl ?: playData!!.dashAudios.first().baseUrl
+        val audioUrls = mutableListOf<String?>()
+        audioUrls.add(audioItem?.baseUrl)
         audioUrls.addAll(audioItem?.backUrl ?: emptyList())
 
         logger.fInfo { "all video hosts: ${videoUrls.map { with(URI(it)) { "$scheme://$authority" } }}" }
@@ -1138,11 +1124,11 @@ class VideoPlayerV3ViewModel(
         //replace cdn
         if (Prefs.enableProxy && state.proxyArea != ProxyArea.MainLand) {
             videoUrl = videoUrl.replaceUrlDomainWithAliCdn()
-            audioUrl = audioUrl?.replaceUrlDomainWithAliCdn()
+            audioUrl = audioUrl.replaceUrlDomainWithAliCdn()
         } else {
             // 如果未通过网络代理获得播放地址，才判断是否应该替换为官方 cdn
             videoUrl = selectOfficialCdnUrl(videoUrls.filterNotNull())
-            audioUrl = if (audioUrls.isNotEmpty()) selectOfficialCdnUrl(audioUrls) else null
+            audioUrl = selectOfficialCdnUrl(audioUrls.filterNotNull())
         }
 
         logger.fInfo {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
@@ -126,9 +126,23 @@ class VideoPlayerV3ViewModel(
     // 一旦命中 surface/codec 输出相关异常，就认为当前 ExoPlayer 出问题，下次回场必须重建
     @Volatile
     private var surfaceBugDetected: Boolean = false
-    // 仅首次打印环境信息（设备 + Media3 版本）
+
+    @Volatile
+    private var suppressPlayerErrors: Boolean = false
+
+    @Volatile
+    private var needRecreateOnStart: Boolean = false
+
+    // 用于断点续播（毫秒）
+    private var pendingResumePositionMs: Long = 0L
+
+    // 防止 onStart 反复触发导致重复重建/prepare
+    private val recreateInProgress = AtomicBoolean(false)
+
+    // 仅首次打印环境信息（设备 + Media3 版本），便于你贴 Logcat 排查
     @Volatile
     private var envLogged: Boolean = false
+
     private val typeFilter = TypeFilter()
     private var danmakuConfig = DanmakuConfig()
 

--- a/bv-player/src/main/kotlin/dev/aaa1115910/bv/player/BvVideoPlayer.kt
+++ b/bv-player/src/main/kotlin/dev/aaa1115910/bv/player/BvVideoPlayer.kt
@@ -9,7 +9,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
@@ -21,24 +24,56 @@ fun BvVideoPlayer(
     modifier: Modifier = Modifier,
     videoPlayer: AbstractVideoPlayer,
 ) {
-    DisposableEffect(Unit) {
-        onDispose {
-            videoPlayer.release()
-        }
-    }
-
     when (videoPlayer) {
         is ExoMediaPlayer -> {
-            var videoPlayerView: PlayerView? by remember { mutableStateOf(null) }
+            var playerView: PlayerView? by remember { mutableStateOf(null) }
+            val lifecycleOwner = LocalLifecycleOwner.current
+
+            // UI 离开时只解绑 View <-> ExoPlayer，不要 release 播放器实例（否则 ViewModel 续播会复用到已销毁实例）
+            // 尽量在 onPause 就先解绑 surface，保证早于 Activity.onStop 的 release
+            DisposableEffect(lifecycleOwner, videoPlayer) {
+                val observer = LifecycleEventObserver { _, event ->
+                    when (event) {
+                        Lifecycle.Event.ON_PAUSE,
+                        Lifecycle.Event.ON_STOP -> {
+                            runCatching { playerView?.player = null }
+                        }
+
+                        Lifecycle.Event.ON_START,
+                        Lifecycle.Event.ON_RESUME -> {
+                            // 回场时强制把 PlayerView 重新指向新 mPlayer
+                            val target = videoPlayer.mPlayer
+                            if (playerView?.player !== target) {
+                                runCatching { playerView?.player = target }
+                            }
+                        }
+
+                        else -> Unit
+                    }
+                }
+                lifecycleOwner.lifecycle.addObserver(observer)
+                onDispose {
+                    lifecycleOwner.lifecycle.removeObserver(observer)
+                    runCatching { playerView?.player = null }
+                    playerView = null
+                }
+            }
+
             AndroidView(
                 modifier = modifier.fillMaxSize(),
                 factory = { ctx ->
-                    videoPlayerView = PlayerView(ctx).apply {
+                    PlayerView(ctx).apply {
                         player = videoPlayer.mPlayer
                         resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL
                         useController = false
+                        playerView = this
                     }
-                    videoPlayerView!!
+                },
+                update = { view ->
+                    // 当 ViewModel 里 initPlayer() 重建了新的 mPlayer 后，这里必须重新绑定
+                    if (view.player !== videoPlayer.mPlayer) {
+                        view.player = videoPlayer.mPlayer
+                    }
                 }
             )
         }


### PR DESCRIPTION
复现方式：
播放视频，进入个人空间，再返回即可看到播放器抽风。
以下是ai总结：

引入“错误抑制机制” (Error Suppression)：

在 Activity 的 onPause/onStop 和 onStart 阶段，主动告诉 ViewModel “现在是动荡期，不要报错”。
在 ViewModel 中，如果处于抑制期，且捕获到 Surface Detach Timeout（Surface 分离超时）或类似的底层渲染错误，不再弹窗报错，而是静默标记“播放器坏了，下次需要重建”。
实现了“快恢复 vs 重建”的双重策略：

快恢复 (Fast Resume)：默认情况下，切后台时只暂停 (pause) 而不释放 (release) 播放器实例，切回来时直接 start，实现秒开。
强制重建 (Recreate)：如果检测到 Surface 出错（surfaceBugDetected）或者配置了慢速模式，切后台时会完全释放播放器。切回来时，ViewModel 会自动重新初始化播放器 (initPlayer)、恢复播放进度 (seekTo) 并自动播放。
精细化的 Surface/View 绑定管理：

在 BvVideoPlayer.kt (UI层) 中，不再依赖 Compose 的 DisposableEffect 自动释放播放器。
改为监听 Lifecycle，在 ON_PAUSE/ON_STOP 时主动将 PlayerView.player 置空（解绑 Surface），在 ON_RESUME 时重新赋值。这为了避免 Surface 被系统回收时播放器还持有的死锁问题。