### PR TITLE
修复bug：动态页也可以进入番剧页面

### DIFF
--- a/app/src/main/kotlin/dev/aaa1115910/bv/activities/video/VideoInfoActivity.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/activities/video/VideoInfoActivity.kt
@@ -35,12 +35,12 @@ class VideoInfoActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        getParamsFromIntent()
         setContent {
             BVTheme {
                 VideoInfoScreen()
             }
         }
+        getParamsFromIntent()
     }
 
     private fun getParamsFromIntent() {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/DynamicsScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/DynamicsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Text
 import dev.aaa1115910.biliapi.entity.user.DynamicVideo
+import dev.aaa1115910.bv.activities.video.SeasonInfoActivity
 import dev.aaa1115910.bv.activities.video.UpInfoActivity
 import dev.aaa1115910.bv.activities.video.VideoInfoActivity
 import dev.aaa1115910.bv.component.LoadingTip
@@ -52,11 +53,23 @@ fun DynamicsScreen(
     val context = LocalContext.current
 
     val onClickVideo: (DynamicVideo) -> Unit = { dynamic ->
-        VideoInfoActivity.actionStart(
-            context = context,
-            aid = dynamic.aid,
-            proxyArea = ProxyArea.checkProxyArea(dynamic.title)
-        )
+        val proxyArea = ProxyArea.checkProxyArea(dynamic.title)
+        val hasSeasonHint = dynamic.seasonId != null || dynamic.epid != null
+
+        if (hasSeasonHint) {
+            SeasonInfoActivity.actionStart(
+                context = context,
+                epId = dynamic.epid,
+                seasonId = dynamic.seasonId,
+                proxyArea = proxyArea
+            )
+        } else {
+            VideoInfoActivity.actionStart(
+                context = context,
+                aid = dynamic.aid,
+                proxyArea = proxyArea
+            )
+        }
     }
 
     LaunchedEffect(Unit) {

--- a/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/entity/user/Dynamic.kt
+++ b/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/entity/user/Dynamic.kt
@@ -119,7 +119,7 @@ data class DynamicVideo(
                         aid = pgc.aid,
                         bvid = null,
                         cid = pgc.cid,
-                        epid = pgc.cid.toInt(),
+                        epid = pgc.epid.toInt(),
                         seasonId = pgc.seasonId.toInt(),
                         title = pgc.title,
                         cover = pgc.cover,


### PR DESCRIPTION
[修复VideoInfoScreen无法跳转到SeasonInfoScreen](https://github.com/Frost819/bv/commit/0869cd98461b57b10e881fd83c28b0b6eb82ba87)你这条没修完，动态页还是进不去