### PR TITLE
完全简化UI 去掉不需要的scale效果 去掉不必要的转换动画 优化资源使用 重做左边导航栏 改变专注颜色

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+BV is a third-party Bilibili Android TV application built with Jetpack Compose. It targets Android 5.0+ (minSdk 21, compileSdk/targetSdk 36) and is optimized for TV (Leanback) environments. The app is a fork with custom UI/UX enhancements over the original `aaa1115910/bv` repo.
+
+**Language**: Kotlin (2.1.21), **Java target**: JDK 21, **Build system**: Gradle with Kotlin DSL and version catalogs.
+
+## Build Commands
+
+```bash
+# Debug build (default flavor, universal APK)
+./gradlew assembleDefaultDebug
+
+# Release build
+./gradlew assembleDefaultRelease
+
+# Lite build (excludes VLC native libs, smaller APK)
+./gradlew assembleLiteDebug
+
+# Run unit tests
+./gradlew test
+
+# Run a single test class
+./gradlew :app:test --tests "dev.aaa1115910.bv.GithubApiTest"
+
+# Clean build
+./gradlew clean
+```
+
+**Note**: Firebase/Google Services integration is conditional — builds work without `google-services.json`, but Firebase features (Crashlytics, Analytics) will be disabled.
+
+**Note**: Release builds require `signing.properties` at the project root pointing to keystore files.
+
+## Module Architecture
+
+```
+app/              → Main Android TV app (Compose UI, ViewModels, Room DB, Koin DI)
+bili-api/          → Bilibili API client (Ktor HTTP, gRPC, JSoup scraping) — Kotlin JVM library
+bili-api-grpc/     → Protocol Buffer definitions and generated gRPC stubs
+bili-subtitle/     → Subtitle parsing library — Kotlin JVM library
+bv-player/         → Custom video player UI component (Media3 + Compose) — Android library
+libs/              → Pre-compiled native libraries (AV1, FFmpeg, VLC, Media3 container) — git submodule
+buildSrc/          → Build configuration (AppConfiguration.kt for version/SDK, ProtobufConfiguration.kt)
+```
+
+**Dependency flow**: `app` → `bili-api`, `bili-subtitle`, `bv-player`; `bili-api` → `bili-api-grpc`
+
+## Key Architecture Patterns
+
+- **MVVM**: ViewModels in `app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/`, screens in `screen/`
+- **Dependency Injection**: Koin with KSP annotations (`@Single`, `@Factory`, etc.)
+- **Database**: Room with entities in `entity/`, DAOs in `dao/`, schemas exported to `app/schemas/`
+- **Networking**: Ktor client (OkHttp engine) for HTTP; gRPC for some Bilibili APIs; JSoup for web scraping
+- **Video playback**: Dual-engine support — Media3 (ExoPlayer) and VLC, with custom decoders (AV1, FFmpeg)
+- **TV navigation**: Custom focus management via `FocusGroup`, D-pad handling, Leanback integration
+
+## Build Variants
+
+**Flavors** (`channel` dimension):
+- `default` — Full build with all features including VLC
+- `lite` — Excludes VLC native libraries for smaller APK size
+
+**Build types**: `debug`, `release`, `r8Test` (R8 minification testing), `alpha`
+
+## Version Management
+
+Version code is derived from git commit count (`git rev-list --count HEAD`). Version name format: `{major}.{minor}.{patch}.r{versionCode}.{shortCommitHash}`. Configured in `buildSrc/src/main/kotlin/AppConfiguration.kt`.
+
+The `applicationId` is `dev.frost819.bv` (changed from original `dev.aaa1115910.bv` to bypass Xiaomi TV blocking). The namespace remains `dev.aaa1115910.bv`.
+
+## Dependency Management
+
+Dependencies are managed via Gradle version catalogs:
+- `gradle/gradle.versions.toml` — Kotlin, AGP, Firebase, third-party libs
+- `gradle/androidx.versions.toml` — AndroidX libraries (Compose, Media3, Room, etc.)
+
+## Important Conventions
+
+- Code and comments are a mix of Chinese and English
+- ProGuard rules are in `app/proguard-rules.pro` — must be updated when adding libraries that use reflection
+- Compose compiler stability config is in `app/compose_compiler_config.conf`
+- APK naming: `BV_{versionCode}_{versionName}.{buildType}_{flavor}_{abi}.apk`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,8 +118,8 @@ android {
     }
     // https://issuetracker.google.com/issues/260059413
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     buildFeatures {
         compose = true
@@ -174,7 +174,7 @@ composeCompiler {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/TopNav.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/TopNav.kt
@@ -164,9 +164,9 @@ enum class PgcTopNavItem(private val pgcType: PgcType) : TopNavItem {
 }
 
 enum class PersonalTopNavItem : TopNavItem {
-    ToView,
     History,
     Favorite,
+    ToView,
     FollowingSeason;
 
     override fun getDisplayName(context: Context): String {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/TopNav.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/TopNav.kt
@@ -21,10 +21,13 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
 import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Tab
+import androidx.tv.material3.TabDefaults
 import androidx.tv.material3.TabRow
+import androidx.tv.material3.TabRowDefaults
 import androidx.tv.material3.TabRowScope
 import androidx.tv.material3.Text
 import dev.aaa1115910.biliapi.entity.pgc.PgcType
@@ -55,11 +58,20 @@ fun TopNav(
             .padding(12.dp, verticalPadding),
         horizontalArrangement = Arrangement.Center
     ) {
+        val pink = Color(0xFFFF69B4)
         TabRow(
             modifier = Modifier
                 .focusRestorer(focusRequester),
             selectedTabIndex = selectedTabIndex,
             separator = { Spacer(modifier = Modifier.width(12.dp)) },
+            indicator = { tabPositions, doesTabRowHaveFocus ->
+                TabRowDefaults.PillIndicator(
+                    currentTabPosition = tabPositions[selectedTabIndex],
+                    doesTabRowHaveFocus = doesTabRowHaveFocus,
+                    activeColor = pink,
+                    inactiveColor = pink.copy(alpha = 0.4f)
+                )
+            }
         ) {
             items.forEachIndexed { index, tab ->
                 NavItemTab(
@@ -89,11 +101,17 @@ private fun TabRowScope.NavItemTab(
 ) {
     val context = LocalContext.current
 
+    val pink = Color(0xFFFF69B4)
     Tab(
         modifier = modifier,
         selected = selected,
         onFocus = onFocus,
-        onClick = onClick
+        onClick = onClick,
+        colors = TabDefaults.pillIndicatorTabColors(
+            focusedContentColor = Color.Black,
+            selectedContentColor = Color.White,
+            focusedSelectedContentColor = Color.Black
+        )
     ) {
         Text(
             modifier = Modifier

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/buttons/CoinButton.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/buttons/CoinButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.Icon
 
 @Composable
@@ -18,6 +19,7 @@ fun CoinButton(
     Button(
         modifier = modifier,
         onClick = onClick,
+        scale = ButtonDefaults.scale(focusedScale = 1f, pressedScale = 1f),
     ) {
         Icon(
             imageVector = if (isCoined) Icons.Rounded.Paid else Icons.Outlined.Paid,

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/buttons/FavoriteButton.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/buttons/FavoriteButton.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.FilterChip
 import androidx.tv.material3.Icon
@@ -53,6 +54,7 @@ fun FavoriteButton(
 
     Button(
         modifier = modifier,
+        scale = ButtonDefaults.scale(focusedScale = 1f, pressedScale = 1f),
         onClick = {
             if (showFavoriteDialog) return@Button
             if (isFavorite) {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/buttons/LikeButton.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/buttons/LikeButton.kt
@@ -56,6 +56,7 @@ fun LikeButton(
         )
     )
     Button(
+        scale = ButtonDefaults.scale(focusedScale = 1f, pressedScale = 1f),
         modifier = modifier.onPreviewKeyEvent {
             when (it.key) {
                 Key.DirectionCenter, Key.Enter, Key.Spacebar -> {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/controllers/PlayStateTips.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/controllers/PlayStateTips.kt
@@ -57,8 +57,7 @@ fun PlayStateTips(
         if (!isPlaying && !isBuffering && !isError) {
             PauseIcon(
                 modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(24.dp)
+                    .align(Alignment.Center)
             )
         }
         if (isBuffering && !isError) {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/controllers/VideoPlayerController.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/controllers/VideoPlayerController.kt
@@ -128,16 +128,8 @@ fun VideoPlayerController(
 
     fun startSeekCountdown() {
         seekCountdown?.cancel()
-        seekCountdown = scope.launch {
-            delay(1000)
-
-            onGoTime(goTime)
-            if (!videoPlayer.isPlaying) onPlay()
-
-            isSeeking = false
-            showInfoSeekController = false
-            hideInfoSeekControllerCountdown?.cancel()
-        }
+        onGoTime(goTime)
+        isSeeking = false
     }
 
     fun onDirectionLeft() {
@@ -202,15 +194,37 @@ fun VideoPlayerController(
                 return true
             }
             Key.MediaPlayPause -> {
+                val wasPlaying = videoPlayer.isPlaying
                 onPlayPause()
+                if (wasPlaying) {
+                    showInfoSeekController = true
+                    hideInfoSeekControllerCountdown?.cancel()
+                } else {
+                    hideInfoSeekControllerCountdown?.cancel()
+                    hideInfoSeekControllerCountdown = scope.launch {
+                        delay(5000)
+                        showInfoSeekController = false
+                    }
+                }
                 return true
             }
             Key.MediaPlay -> {
-                if (!videoPlayer.isPlaying) onPlay()
+                if (!videoPlayer.isPlaying) {
+                    onPlay()
+                    hideInfoSeekControllerCountdown?.cancel()
+                    hideInfoSeekControllerCountdown = scope.launch {
+                        delay(5000)
+                        showInfoSeekController = false
+                    }
+                }
                 return true
             }
             Key.MediaPause -> {
-                if (videoPlayer.isPlaying) onPause()
+                if (videoPlayer.isPlaying) {
+                    onPause()
+                    showInfoSeekController = true
+                    hideInfoSeekControllerCountdown?.cancel()
+                }
                 return true
             }
         }
@@ -229,7 +243,20 @@ fun VideoPlayerController(
                         if (uiState.showBackToStart) {
                             onBackToStart()
                         } else {
+                            val wasPlaying = videoPlayer.isPlaying
                             onPlayPause()
+                            if (wasPlaying) {
+                                // just paused — show control bar and keep it visible
+                                showInfoSeekController = true
+                                hideInfoSeekControllerCountdown?.cancel()
+                            } else {
+                                // just resumed — start auto-hide countdown
+                                hideInfoSeekControllerCountdown?.cancel()
+                                hideInfoSeekControllerCountdown = scope.launch {
+                                    delay(5000)
+                                    showInfoSeekController = false
+                                }
+                            }
                         }
                         return true
                     }
@@ -264,8 +291,8 @@ fun VideoPlayerController(
             .background(Color.Black)
             .focusable()
             .onPreviewKeyEvent { event ->
-                // 重置 info 控制器的隐藏倒计时 (只要有按键活动就重置)
-                if (showInfoSeekController) {
+                // 重置 info 控制器的隐藏倒计时 (只要有按键活动就重置，暂停时保持显示)
+                if (showInfoSeekController && videoPlayer.isPlaying) {
                     hideInfoSeekControllerCountdown?.cancel()
                     hideInfoSeekControllerCountdown = scope.launch {
                         delay(5000)

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/LargeVideoCard.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/LargeVideoCard.kt
@@ -1,6 +1,5 @@
 package dev.aaa1115910.bv.component.videocard
 
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -23,7 +22,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -52,10 +50,6 @@ fun LargeVideoCard(
     val view = LocalView.current
 
     var hasFocus by remember { mutableStateOf(false) }
-    val scale by animateFloatAsState(
-        targetValue = if (hasFocus) 1f else 0.95f,
-        label = "large video card scale"
-    )
 
     val height = 160.dp
     val reasonColor = Color.Red
@@ -67,7 +61,6 @@ fun LargeVideoCard(
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .scale(scale)
             .onFocusChanged { hasFocus = it.isFocused }
             .focusedBorder(MaterialTheme.shapes.medium)
             .clickable { onClick() },

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/SeasonCard.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/SeasonCard.kt
@@ -65,9 +65,10 @@ fun SeasonCard(
             pressedContainerColor = MaterialTheme.colorScheme.surface
         ),
         shape = ClickableSurfaceDefaults.shape(shape = MaterialTheme.shapes.large),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1f, pressedScale = 1f),
         border = ClickableSurfaceDefaults.border(
             focusedBorder = Border(
-                border = BorderStroke(width = 3.dp, color = Color.White),
+                border = BorderStroke(width = 3.dp, color = Color(0xFFFF69B4)),
                 shape = MaterialTheme.shapes.large
             )
         )

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/SmallVideoCard.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/SmallVideoCard.kt
@@ -93,9 +93,10 @@ fun SmallVideoCard(
                     if (!focusState.hasFocus) showActions = false
                 },
             shape = CardDefaults.shape(MaterialTheme.shapes.large),
+            scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f),
             border = CardDefaults.border(
                 focusedBorder = Border(
-                    border = BorderStroke(3.dp, MaterialTheme.colorScheme.border),
+                    border = BorderStroke(3.dp, Color(0xFFFF69B4)),
                     shape = MaterialTheme.shapes.large
                 )
             )

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/SmallVideoCard.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/SmallVideoCard.kt
@@ -1,6 +1,5 @@
 package dev.aaa1115910.bv.component.videocard
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
@@ -80,13 +80,19 @@ fun SmallVideoCard(
     }
 
     var cardFocused by remember { mutableStateOf(false) }
-    val pink = Color(0xFFFF69B4)
+    val pinkBg = remember { Color(0xFFFF69B4).copy(alpha = 0.35f) }
+    val shape = MaterialTheme.shapes.large
 
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(MaterialTheme.shapes.large)
-            .background(if (cardFocused) pink.copy(alpha = 0.15f) else Color.Transparent)
+            .clip(shape)
+            .drawBehind {
+                if (cardFocused) {
+                    drawRect(pinkBg)
+                }
+            }
+            .padding(6.dp)
     ) {
         Card(
             onClick = { if (!showActions) onClick() },
@@ -104,11 +110,9 @@ fun SmallVideoCard(
             shape = CardDefaults.shape(MaterialTheme.shapes.large),
             scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f),
             border = CardDefaults.border(
-                focusedBorder = Border(
-                    border = BorderStroke(2.dp, pink),
-                    shape = MaterialTheme.shapes.large
-                )
-            )
+                focusedBorder = Border.None,
+                pressedBorder = Border.None
+            ),
         ) {
             if (showActions) {
                 Row(
@@ -276,6 +280,7 @@ fun CardInfo(
         Text(
             text = title,
             style = MaterialTheme.typography.titleMedium,
+            minLines = 2,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.fillMaxWidth()

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/SmallVideoCard.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/SmallVideoCard.kt
@@ -79,7 +79,15 @@ fun SmallVideoCard(
         }
     }
 
-    Column(modifier = modifier.fillMaxWidth()) {
+    var cardFocused by remember { mutableStateOf(false) }
+    val pink = Color(0xFFFF69B4)
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.large)
+            .background(if (cardFocused) pink.copy(alpha = 0.15f) else Color.Transparent)
+    ) {
         Card(
             onClick = { if (!showActions) onClick() },
             onLongClick = {
@@ -90,13 +98,14 @@ fun SmallVideoCard(
                 .fillMaxWidth()
                 .aspectRatio(1.6f)
                 .onFocusChanged { focusState ->
+                    cardFocused = focusState.hasFocus
                     if (!focusState.hasFocus) showActions = false
                 },
             shape = CardDefaults.shape(MaterialTheme.shapes.large),
             scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f),
             border = CardDefaults.border(
                 focusedBorder = Border(
-                    border = BorderStroke(3.dp, Color(0xFFFF69B4)),
+                    border = BorderStroke(2.dp, pink),
                     shape = MaterialTheme.shapes.large
                 )
             )

--- a/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/VideosRow.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/component/videocard/VideosRow.kt
@@ -1,6 +1,5 @@
 package dev.aaa1115910.bv.component.videocard
 
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -53,10 +52,7 @@ fun VideosRow(
     val density = LocalDensity.current
     var hasFocus by remember { mutableStateOf(false) }
     val titleColor = if (hasFocus) Color.White else Color.White.copy(alpha = 0.6f)
-    val titleFontSize by animateFloatAsState(
-        targetValue = if (hasFocus) 30f else 14f,
-        label = "title font size"
-    )
+    val titleFontSize = if (hasFocus) 30f else 14f
     var rowHeight by remember { mutableStateOf(0.dp) }
 
     Column(

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/SeasonInfoScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/SeasonInfoScreen.kt
@@ -610,7 +610,7 @@ fun SeasonInfoPart(
     Row(
         modifier = modifier
             .padding(horizontal = 50.dp, vertical = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(24.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         SeasonCover(
@@ -892,7 +892,7 @@ fun SeasonEpisodeRow(
                 .padding(top = 15.dp)
                 .focusRestorer(focusRequester),
             contentPadding = PaddingValues(horizontal = 50.dp),
-            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item {
                 Surface(
@@ -1103,7 +1103,7 @@ private fun SeasonSelectorContent(
                     modifier = Modifier.padding(bottom = 48.dp),
                     state = rowState,
                     contentPadding = PaddingValues(horizontal = 48.dp),
-                    horizontalArrangement = Arrangement.spacedBy(24.dp)
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     itemsIndexed(items = seasons) { index, season ->
                         Card(

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/SeasonInfoScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/SeasonInfoScreen.kt
@@ -506,19 +506,13 @@ fun SeasonCover(
         modifier = modifier.onFocusChanged { hasFocus = it.hasFocus },
         onClick = onClick,
         shape = CardDefaults.shape(shape = MaterialTheme.shapes.large),
-        glow = CardDefaults.glow(
-            focusedGlow = Glow(
-                elevationColor = MaterialTheme.colorScheme.inverseSurface,
-                elevation = 16.dp
+        scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f),
+        border = CardDefaults.border(
+            focusedBorder = Border(
+                border = BorderStroke(3.dp, Color(0xFFFF69B4)),
+                shape = MaterialTheme.shapes.large
             )
-        ),
-        border = if (Build.VERSION.SDK_INT < 31) {
-            CardDefaults.border()
-        } else {
-            CardDefaults.border(
-                focusedBorder = Border(BorderStroke(0.dp, Color.Transparent))
-            )
-        }
+        )
     ) {
         Box {
             AsyncImage(
@@ -1110,19 +1104,13 @@ private fun SeasonSelectorContent(
                                     season.seasonId == currentSeasonId,
                                     Modifier.bringIntoViewRequester(bringIntoViewRequester)
                                 ),
-                            glow = CardDefaults.glow(
-                                focusedGlow = Glow(
-                                    elevationColor = MaterialTheme.colorScheme.inverseSurface,
-                                    elevation = 16.dp
+                            scale = CardDefaults.scale(focusedScale = 1f, pressedScale = 1f),
+                            border = CardDefaults.border(
+                                focusedBorder = Border(
+                                    border = BorderStroke(3.dp, Color(0xFFFF69B4)),
+                                    shape = MaterialTheme.shapes.large
                                 )
                             ),
-                            border = if (Build.VERSION.SDK_INT < 31) {
-                                CardDefaults.border()
-                            } else {
-                                CardDefaults.border(
-                                    focusedBorder = Border(BorderStroke(0.dp, Color.Transparent))
-                                )
-                            },
                             onClick = {
                                 onClickSeason(season.seasonId)
                             }

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/SeasonInfoScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/SeasonInfoScreen.kt
@@ -84,7 +84,9 @@ import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Tab
+import androidx.tv.material3.TabDefaults
 import androidx.tv.material3.TabRow
+import androidx.tv.material3.TabRowDefaults
 import androidx.tv.material3.Text
 import coil.compose.AsyncImage
 import dev.aaa1115910.biliapi.entity.ApiType
@@ -771,6 +773,14 @@ fun SeasonEpisodesDialog(
                                 },
                             selectedTabIndex = selectedTabIndex,
                             separator = { Spacer(modifier = Modifier.width(12.dp)) },
+                            indicator = { tabPositions, doesTabRowHaveFocus ->
+                                TabRowDefaults.PillIndicator(
+                                    currentTabPosition = tabPositions[selectedTabIndex],
+                                    doesTabRowHaveFocus = doesTabRowHaveFocus,
+                                    activeColor = Color(0xFFFF69B4),
+                                    inactiveColor = Color(0xFFFF69B4).copy(alpha = 0.4f)
+                                )
+                            }
                         ) {
                             for (i in 0 until tabCount) {
                                 Tab(
@@ -779,6 +789,11 @@ fun SeasonEpisodesDialog(
                                     ) else Modifier,
                                     selected = i == selectedTabIndex,
                                     onFocus = { selectedTabIndex = i },
+                                    colors = TabDefaults.pillIndicatorTabColors(
+                                        focusedContentColor = Color.Black,
+                                        selectedContentColor = Color.White,
+                                        focusedSelectedContentColor = Color.Black
+                                    )
                                 ) {
                                     Text(
                                         text = "P${i * 20 + 1}-${(i + 1) * 20}",

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/TagScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/TagScreen.kt
@@ -102,7 +102,7 @@ fun TagScreen(
                         fontSize = 24.sp
                     )
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(2.dp)
                     ) {
                         Text(
                             text = stringResource(
@@ -128,7 +128,7 @@ fun TagScreen(
             state = gridState,
             contentPadding = PaddingValues(24.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
-            horizontalArrangement = Arrangement.spacedBy(24.dp)
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             items(
                 items = uiState.value.videoList,

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoInfoScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoInfoScreen.kt
@@ -956,10 +956,22 @@ fun VideoInfoData(
                             onClick = { onClickTip(tag) },
                             scale = SuggestionChipDefaults.scale(focusedScale = 1f, pressedScale = 1f),
                             colors = SuggestionChipDefaults.colors(
+                                containerColor = Color.Transparent,
+                                contentColor = Color.White,
                                 focusedContainerColor = pink,
                                 focusedContentColor = Color.Black,
                                 pressedContainerColor = pink,
                                 pressedContentColor = Color.Black
+                            ),
+                            border = SuggestionChipDefaults.border(
+                                border = Border(
+                                    border = BorderStroke(1.dp, Color.White),
+                                    shape = MaterialTheme.shapes.small
+                                ),
+                                focusedBorder = Border(
+                                    border = BorderStroke(1.dp, pink),
+                                    shape = MaterialTheme.shapes.small
+                                )
                             )
                         ) {
                             Text(text = tag.name)

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoInfoScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoInfoScreen.kt
@@ -1116,6 +1116,7 @@ fun VideoPartButton(
             focusedContainerColor = MaterialTheme.colorScheme.inverseSurface,
             pressedContainerColor = MaterialTheme.colorScheme.inverseSurface
         ),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1f, pressedScale = 1f),
         shape = ClickableSurfaceDefaults.shape(shape = MaterialTheme.shapes.medium),
         onClick = { onClick() }
     ) {
@@ -1153,6 +1154,7 @@ fun VideoPartRowButton(
             focusedContainerColor = MaterialTheme.colorScheme.inverseSurface,
             pressedContainerColor = MaterialTheme.colorScheme.inverseSurface
         ),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1f, pressedScale = 1f),
         shape = ClickableSurfaceDefaults.shape(shape = MaterialTheme.shapes.medium),
         onClick = onClick
     ) {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoInfoScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/VideoInfoScreen.kt
@@ -84,10 +84,13 @@ import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.LocalTextStyle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.SuggestionChip
+import androidx.tv.material3.SuggestionChipDefaults
 import androidx.tv.material3.Surface
 import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Tab
+import androidx.tv.material3.TabDefaults
 import androidx.tv.material3.TabRow
+import androidx.tv.material3.TabRowDefaults
 import androidx.tv.material3.Text
 import coil.compose.AsyncImage
 import dev.aaa1115910.biliapi.entity.ApiType
@@ -852,6 +855,7 @@ fun VideoInfoData(
             shape = ClickableSurfaceDefaults.shape(
                 shape = MaterialTheme.shapes.large,
             ),
+            scale = ClickableSurfaceDefaults.scale(focusedScale = 1f, pressedScale = 1f),
             border = ClickableSurfaceDefaults.border(
                 focusedBorder = Border(
                     border = BorderStroke(width = 3.dp, color = MaterialTheme.colorScheme.border),
@@ -946,10 +950,18 @@ fun VideoInfoData(
                     contentPadding = PaddingValues(horizontal = 5.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
+                    val pink = Color(0xFFFF69B4)
                     items(items = tags) { tag ->
-                        SuggestionChip(onClick = {
-                            onClickTip(tag)
-                        }) {
+                        SuggestionChip(
+                            onClick = { onClickTip(tag) },
+                            scale = SuggestionChipDefaults.scale(focusedScale = 1f, pressedScale = 1f),
+                            colors = SuggestionChipDefaults.colors(
+                                focusedContainerColor = pink,
+                                focusedContentColor = Color.Black,
+                                pressedContainerColor = pink,
+                                pressedContentColor = Color.Black
+                            )
+                        ) {
                             Text(text = tag.name)
                         }
                     }
@@ -1401,6 +1413,15 @@ private fun VideoPartListDialog(
                             },
                         selectedTabIndex = selectedTabIndex,
                         separator = { Spacer(modifier = Modifier.width(12.dp)) },
+                        indicator = { tabPositions, doesTabRowHaveFocus ->
+                            val pink = Color(0xFFFF69B4)
+                            TabRowDefaults.PillIndicator(
+                                currentTabPosition = tabPositions[selectedTabIndex],
+                                doesTabRowHaveFocus = doesTabRowHaveFocus,
+                                activeColor = pink,
+                                inactiveColor = pink.copy(alpha = 0.4f)
+                            )
+                        }
                     ) {
                         for (i in 0 until tabCount) {
                             Tab(
@@ -1409,6 +1430,11 @@ private fun VideoPartListDialog(
                                 ) else Modifier,
                                 selected = i == selectedTabIndex,
                                 onFocus = { selectedTabIndex = i },
+                                colors = TabDefaults.pillIndicatorTabColors(
+                                    focusedContentColor = Color.Black,
+                                    selectedContentColor = Color.White,
+                                    focusedSelectedContentColor = Color.Black
+                                )
                             ) {
                                 Text(
                                     text = "P${i * 20 + 1}-${(i + 1) * 20}",
@@ -1508,6 +1534,15 @@ private fun VideoUgcListDialog(
                             },
                         selectedTabIndex = selectedTabIndex,
                         separator = { Spacer(modifier = Modifier.width(12.dp)) },
+                        indicator = { tabPositions, doesTabRowHaveFocus ->
+                            val pink = Color(0xFFFF69B4)
+                            TabRowDefaults.PillIndicator(
+                                currentTabPosition = tabPositions[selectedTabIndex],
+                                doesTabRowHaveFocus = doesTabRowHaveFocus,
+                                activeColor = pink,
+                                inactiveColor = pink.copy(alpha = 0.4f)
+                            )
+                        }
                     ) {
                         for (i in 0 until tabCount) {
                             Tab(
@@ -1516,6 +1551,11 @@ private fun VideoUgcListDialog(
                                 ) else Modifier,
                                 selected = i == selectedTabIndex,
                                 onFocus = { selectedTabIndex = i },
+                                colors = TabDefaults.pillIndicatorTabColors(
+                                    focusedContentColor = Color.Black,
+                                    selectedContentColor = Color.White,
+                                    focusedSelectedContentColor = Color.Black
+                                )
                             ) {
                                 Text(
                                     text = "P${i * 20 + 1}-${(i + 1) * 20}",

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/HomeContent.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/HomeContent.kt
@@ -1,11 +1,6 @@
 package dev.aaa1115910.bv.screen.main
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -167,19 +162,9 @@ fun HomeContent(
                     return@onPreviewKeyEvent false
                 },
         ) {
-            AnimatedContent(
+            Crossfade(
                 targetState = selectedTab,
-                label = "home animated content",
-                transitionSpec = {
-                    val coefficient = 10
-                    if (reorderedItems.indexOf(targetState) < reorderedItems.indexOf(initialState)) {
-                        fadeIn() + slideInHorizontally { -it / coefficient } togetherWith
-                                fadeOut() + slideOutHorizontally { it / coefficient }
-                    } else {
-                        fadeIn() + slideInHorizontally { it / coefficient } togetherWith
-                                fadeOut() + slideOutHorizontally { -it / coefficient }
-                    }
-                }
+                label = "home crossfade"
             ) { screen ->
                 when (screen) {
                     HomeTopNavItem.Recommend -> RecommendScreen()

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/LeftNaviContent.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/LeftNaviContent.kt
@@ -1,10 +1,15 @@
 package dev.aaa1115910.bv.screen.main
 
-import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
@@ -14,14 +19,13 @@ import androidx.compose.material.icons.filled.OndemandVideo
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.NavigationRail
-import androidx.compose.material3.NavigationRailItem
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,16 +35,14 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.DrawerValue
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.Surface
-import androidx.tv.material3.SurfaceDefaults
-import androidx.tv.material3.rememberDrawerState
 import coil.compose.AsyncImage
 import dev.aaa1115910.bv.ui.theme.BVTheme
 import dev.aaa1115910.bv.util.isDpadRight
@@ -59,68 +61,41 @@ fun LeftNaviContent(
     onLogin: () -> Unit
 ) {
     var selectedItem by remember { mutableStateOf(LeftNaviItem.Home) }
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(selectedItem) {
         onLeftNaviItemChanged(selectedItem)
     }
 
-    NavigationRail(
+    Column(
         modifier = modifier
             .fillMaxHeight()
+            .width(48.dp)
+            .background(Color.White.copy(alpha = 0.05f))
+            .padding(vertical = 12.dp)
             .onPreviewKeyEvent { keyEvent ->
-                if (keyEvent.isDpadRight()) {
-                    if (keyEvent.isKeyDown()) {
-                        onFocusToContent()
-                        return@onPreviewKeyEvent true
-                    }
+                if (keyEvent.isDpadRight() && keyEvent.isKeyDown()) {
+                    focusManager.moveFocus(FocusDirection.Right)
+                    return@onPreviewKeyEvent true
                 }
                 false
             },
-        containerColor = Color.White.copy(alpha = 0.05f),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        var userIsFocused by remember { mutableStateOf(false) }
-        NavigationRailItem(
-            modifier = Modifier.onFocusChanged {
-                userIsFocused = it.hasFocus
-            },
-            onClick = {
-                if (isLogin) {
-                    onShowUserPanel()
-                } else {
-                    onLogin()
-                }
-            },
-            selected = userIsFocused,
-            icon = {
-                if (isLogin) {
-                    Surface(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(CircleShape),
-                        colors = SurfaceDefaults.colors(
-                            containerColor = Color.Gray
-                        )
-                    ) {
-                        AsyncImage(
-                            modifier = Modifier
-                                .size(40.dp)
-                                .clip(CircleShape),
-                            model = avatar,
-                            contentDescription = null,
-                            contentScale = ContentScale.FillBounds
-                        )
-                    }
-                } else {
-                    Icon(
-                        imageVector = LeftNaviItem.User.displayIcon,
-                        contentDescription = null
-                    )
-                }
-            }
+        // User avatar/icon
+        NavIcon(
+            icon = if (!isLogin) LeftNaviItem.User.displayIcon else null,
+            avatarUrl = if (isLogin) avatar else null,
+            isSelected = false,
+            onClick = { if (isLogin) onShowUserPanel() else onLogin() }
         )
+
+        // Main nav items
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.Center
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterVertically)
         ) {
             listOf(
                 LeftNaviItem.Search,
@@ -129,47 +104,64 @@ fun LeftNaviContent(
                 LeftNaviItem.UGC,
                 LeftNaviItem.PGC,
             ).forEach { item ->
-                var isFocused by remember { mutableStateOf(false) }
-                val indicatorColor by animateColorAsState(
-                    targetValue = if (item == selectedItem) {
-                        MaterialTheme.colorScheme.border
-                    } else Color.Transparent,
-                    label = "selectionIndicatorColor"
-                )
-                NavigationRailItem(
-                    modifier = Modifier
-                        .onFocusChanged { isFocused = it.hasFocus }
-                        .selectionIndicator(
-                            animateColorAsState(
-                                targetValue = indicatorColor,
-                                label = "selectionIndicatorColor"
-                            ).value
-                        ),
-                    onClick = { selectedItem = item },
-                    selected = isFocused,
-                    icon = {
-                        Icon(
-                            imageVector = item.displayIcon,
-                            contentDescription = null
-                        )
-                    }
+                NavIcon(
+                    icon = item.displayIcon,
+                    isSelected = item == selectedItem,
+                    onClick = { selectedItem = item }
                 )
             }
         }
-        var settingsIsFocused by remember { mutableStateOf(false) }
-        NavigationRailItem(
-            modifier = Modifier.onFocusChanged {
-                settingsIsFocused = it.hasFocus
-            },
-            onClick = onOpenSettings,
-            selected = settingsIsFocused,
-            icon = {
-                Icon(
-                    imageVector = LeftNaviItem.Settings.displayIcon,
-                    contentDescription = null
-                )
-            }
+
+        // Settings
+        NavIcon(
+            icon = LeftNaviItem.Settings.displayIcon,
+            isSelected = false,
+            onClick = onOpenSettings
         )
+    }
+}
+
+@Composable
+private fun NavIcon(
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    avatarUrl: String? = null,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val pink = Color(0xFFFF69B4)
+
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .onFocusChanged { isFocused = it.hasFocus }
+            .border(
+                width = if (isFocused) 2.dp else 0.dp,
+                color = if (isFocused) pink else Color.Transparent,
+                shape = MaterialTheme.shapes.small
+            )
+            .selectionIndicator(if (isSelected) pink else Color.Transparent)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        if (avatarUrl != null) {
+            AsyncImage(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(CircleShape),
+                model = avatarUrl,
+                contentDescription = null,
+                contentScale = ContentScale.FillBounds
+            )
+        } else if (icon != null) {
+            Icon(
+                modifier = Modifier.size(24.dp),
+                imageVector = icon,
+                contentDescription = null,
+                tint = if (isFocused || isSelected) pink else Color.White.copy(alpha = 0.8f)
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/PersonalContent.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/PersonalContent.kt
@@ -1,11 +1,6 @@
 package dev.aaa1115910.bv.screen.main
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -124,19 +119,9 @@ fun PersonalContent(
                     return@onKeyEvent false
                 },
         ) {
-            AnimatedContent(
+            Crossfade(
                 targetState = selectedTab,
-                label = "personal animated content",
-                transitionSpec = {
-                    val coefficient = 10
-                    if (targetState.ordinal < initialState.ordinal) {
-                        fadeIn() + slideInHorizontally { -it / coefficient } togetherWith
-                                fadeOut() + slideOutHorizontally { it / coefficient }
-                    } else {
-                        fadeIn() + slideInHorizontally { it / coefficient } togetherWith
-                                fadeOut() + slideOutHorizontally { -it / coefficient }
-                    }
-                }
+                label = "personal crossfade"
             ) { screen ->
                 when (screen) {
                     PersonalTopNavItem.ToView -> {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/PersonalContent.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/PersonalContent.kt
@@ -49,7 +49,7 @@ fun PersonalContent(
 ) {
     val scope = rememberCoroutineScope()
 
-    var selectedTab by remember { mutableStateOf(PersonalTopNavItem.ToView) }
+    var selectedTab by remember { mutableStateOf(PersonalTopNavItem.History) }
     var focusOnContent by remember { mutableStateOf(false) }
 
     fun refreshPageData(nav: PersonalTopNavItem) {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/PgcContent.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/PgcContent.kt
@@ -1,11 +1,6 @@
 package dev.aaa1115910.bv.screen.main
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -130,19 +125,9 @@ fun PgcContent(
                     return@onPreviewKeyEvent false
                 }
         ) {
-            AnimatedContent(
+            Crossfade(
                 targetState = selectedTab,
-                label = "pgc animated content",
-                transitionSpec = {
-                    val coefficient = 10
-                    if (targetState.ordinal < initialState.ordinal) {
-                        fadeIn() + slideInHorizontally { -it / coefficient } togetherWith
-                                fadeOut() + slideOutHorizontally { it / coefficient }
-                    } else {
-                        fadeIn() + slideInHorizontally { it / coefficient } togetherWith
-                                fadeOut() + slideOutHorizontally { -it / coefficient }
-                    }
-                }
+                label = "pgc crossfade"
             ) { screen ->
                 when (screen) {
                     PgcTopNavItem.Anime -> AnimeContent(lazyListState = animeState)

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/UgcContent.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/UgcContent.kt
@@ -1,12 +1,7 @@
 package dev.aaa1115910.bv.screen.main
 
 import android.util.Log
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -92,19 +87,9 @@ fun UgcContent(
                     return@onPreviewKeyEvent false
                 },
         ) {
-            AnimatedContent(
+            Crossfade(
                 targetState = selectedTab,
-                label = "ugc animated content",
-                transitionSpec = {
-                    val coefficient = 10
-                    if (targetState.ordinal < initialState.ordinal) {
-                        fadeIn() + slideInHorizontally { -it / coefficient } togetherWith
-                                fadeOut() + slideOutHorizontally { it / coefficient }
-                    } else {
-                        fadeIn() + slideInHorizontally { it / coefficient } togetherWith
-                                fadeOut() + slideOutHorizontally { -it / coefficient }
-                    }
-                }
+                label = "ugc crossfade"
             ) { screen ->
                 val range = (screen.ordinal)..minOf(screen.ordinal + 2, ugcTopNavItems.size - 1)
                 for (i in range) {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/DynamicsScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/DynamicsScreen.kt
@@ -87,7 +87,7 @@ fun DynamicsScreen(
             state = gridState,
             columns = GridCells.Fixed(4),
             contentPadding = PaddingValues(24.dp),
-            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             itemsIndexed(

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/DynamicsScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/DynamicsScreen.kt
@@ -92,7 +92,7 @@ fun DynamicsScreen(
         ) {
             itemsIndexed(
                 items = dynamicViewModel.dynamicList,
-                key = { index, _ -> index }
+                key = { _, item -> item.aid }
             ) { _, item ->
                 SmallVideoCard(
                     data = remember(item) {         // `VideoCardData` 只在 item 变动时重建

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/PopularScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/PopularScreen.kt
@@ -80,7 +80,7 @@ fun PopularScreen(
         state = gridState,
         columns = GridCells.Fixed(4),
         contentPadding = PaddingValues(24.dp),
-        horizontalArrangement = Arrangement.spacedBy(24.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         itemsIndexed(

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/PopularScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/PopularScreen.kt
@@ -85,7 +85,7 @@ fun PopularScreen(
     ) {
         itemsIndexed(
             items = popularViewModel.popularVideoList,
-            key = { index, _ -> index }
+            key = { _, item -> item.aid }
         ) { _, item ->
             SmallVideoCard(
                 data = remember(item) {         // `VideoCardData` 只在 item 变动时重建

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/RecommendScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/RecommendScreen.kt
@@ -81,7 +81,7 @@ fun RecommendScreen(
         state = gridState,
         columns = GridCells.Fixed(4),
         contentPadding = PaddingValues(24.dp),
-        horizontalArrangement = Arrangement.spacedBy(24.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         itemsIndexed(

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/RecommendScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/home/RecommendScreen.kt
@@ -86,7 +86,7 @@ fun RecommendScreen(
     ) {
         itemsIndexed(
             items = recommendViewModel.recommendVideoList,
-            key = { index, _ -> index }
+            key = { _, item -> item.aid }
         ) { _, item ->
             SmallVideoCard(
                 data = remember(item) {         // `VideoCardData` 只在 item 变动时重建

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/pgc/PgcCommon.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/pgc/PgcCommon.kt
@@ -164,7 +164,7 @@ fun PgcFeedVideoRow(
     LazyRow(
         modifier = modifier,
         contentPadding = PaddingValues(horizontal = 24.dp),
-        horizontalArrangement = Arrangement.spacedBy(24.dp)
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {
         data.forEachIndexed { index, feedItem ->
             val cardModifier = if (index == data.lastIndex) {
@@ -405,7 +405,7 @@ fun PgcFeatureButton(
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(2.dp)
             ) {
                 Icon(imageVector = icon, contentDescription = null)
                 Text(
@@ -441,7 +441,7 @@ fun PgcFeatureButton(
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(2.dp)
             ) {
                 Icon(
                     modifier = Modifier.size(24.dp),

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/pgc/PgcCommon.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/pgc/PgcCommon.kt
@@ -395,6 +395,7 @@ fun PgcFeatureButton(
             focusedContainerColor = MaterialTheme.colorScheme.inverseSurface,
             pressedContainerColor = MaterialTheme.colorScheme.inverseSurface
         ),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1f, pressedScale = 1f),
         shape = ClickableSurfaceDefaults.shape(shape = MaterialTheme.shapes.large),
         onClick = onClick
     ) {
@@ -430,6 +431,7 @@ fun PgcFeatureButton(
             focusedContainerColor = MaterialTheme.colorScheme.inverseSurface,
             pressedContainerColor = MaterialTheme.colorScheme.inverseSurface
         ),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1f, pressedScale = 1f),
         shape = ClickableSurfaceDefaults.shape(shape = MaterialTheme.shapes.large),
         onClick = onClick
     ) {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/pgc/PgcIndexScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/pgc/PgcIndexScreen.kt
@@ -140,7 +140,7 @@ fun PgcIndexScreen(
             columns = GridCells.Fixed(6),
             contentPadding = PaddingValues(24.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
-            horizontalArrangement = Arrangement.spacedBy(24.dp)
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             itemsIndexed(items = pgcItems) { index, pgcItem ->
                 SeasonCard(

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/ugc/UgcCommon.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/main/ugc/UgcCommon.kt
@@ -59,7 +59,7 @@ fun UgcRegionScaffold(
         state = gridState,
         columns = GridCells.Fixed(4),
         contentPadding = PaddingValues(24.dp),
-        horizontalArrangement = Arrangement.spacedBy(24.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         // 用index的话快速刷新有概率闪退

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/search/SearchResultScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/search/SearchResultScreen.kt
@@ -269,7 +269,7 @@ fun SearchResultScreen(
                 columns = GridCells.Fixed(rowSize),
                 contentPadding = PaddingValues(24.dp),
                 verticalArrangement = Arrangement.spacedBy(24.dp),
-                horizontalArrangement = Arrangement.spacedBy(24.dp)
+                horizontalArrangement = Arrangement.spacedBy(2.dp)
             ) {
                 itemsIndexed(
                     items = when (searchResult.type) {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/FavoriteScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/FavoriteScreen.kt
@@ -33,8 +33,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.MaterialTheme
+import androidx.compose.ui.graphics.Color
 import androidx.tv.material3.Tab
+import androidx.tv.material3.TabDefaults
 import androidx.tv.material3.TabRow
+import androidx.tv.material3.TabRowDefaults
 import androidx.tv.material3.Text
 import dev.aaa1115910.biliapi.entity.FavoriteFolderMetadata
 import dev.aaa1115910.bv.activities.video.UpInfoActivity
@@ -116,6 +119,15 @@ fun FavoriteScreen(
                 .focusRestorer(focusRequester),
             selectedTabIndex = currentTabIndex,
             separator = { Spacer(modifier = Modifier.width(12.dp)) },
+            indicator = { tabPositions, doesTabRowHaveFocus ->
+                val pink = Color(0xFFFF69B4)
+                TabRowDefaults.PillIndicator(
+                    currentTabPosition = tabPositions[currentTabIndex],
+                    doesTabRowHaveFocus = doesTabRowHaveFocus,
+                    activeColor = pink,
+                    inactiveColor = pink.copy(alpha = 0.4f)
+                )
+            }
         ) {
             favoriteViewModel.favoriteFolderMetadataList.forEachIndexed { index, folderMetadata ->
                 Tab(
@@ -127,7 +139,12 @@ fun FavoriteScreen(
                             updateCurrentFavoriteFolder(folderMetadata)
                         }
                     },
-                    onClick = { updateCurrentFavoriteFolder(folderMetadata) }
+                    onClick = { updateCurrentFavoriteFolder(folderMetadata) },
+                    colors = TabDefaults.pillIndicatorTabColors(
+                        focusedContentColor = Color.Black,
+                        selectedContentColor = Color.White,
+                        focusedSelectedContentColor = Color.Black
+                    )
                 ) {
                     Box(
                         modifier = Modifier.height(32.dp),

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/FavoriteScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/FavoriteScreen.kt
@@ -168,7 +168,7 @@ fun FavoriteScreen(
             columns = GridCells.Fixed(4),
             contentPadding = PaddingValues(24.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
-            horizontalArrangement = Arrangement.spacedBy(24.dp)
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             if (favoriteViewModel.favorites.isNotEmpty()) {
                 items(

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/FollowScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/FollowScreen.kt
@@ -170,9 +170,10 @@ fun UpCard(
             pressedContainerColor = MaterialTheme.colorScheme.surface
         ),
         shape = ClickableSurfaceDefaults.shape(shape = MaterialTheme.shapes.large),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1f, pressedScale = 1f),
         border = ClickableSurfaceDefaults.border(
             focusedBorder = Border(
-                border = BorderStroke(width = 3.dp, color = Color.White),
+                border = BorderStroke(width = 3.dp, color = Color(0xFFFF69B4)),
                 shape = MaterialTheme.shapes.large
             )
         ),

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/FollowingSeasonScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/FollowingSeasonScreen.kt
@@ -102,7 +102,7 @@ fun FollowingSeasonScreen(
             columns = GridCells.Fixed(6),
             contentPadding = PaddingValues(24.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
-            horizontalArrangement = Arrangement.spacedBy(24.dp)
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             if (followingSeasons.isNotEmpty()) {
                 itemsIndexed(items = followingSeasons) { index, followingSeason ->

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/HistoryScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/HistoryScreen.kt
@@ -64,7 +64,7 @@ fun HistoryScreen(
         columns = GridCells.Fixed(4),
         contentPadding = PaddingValues(24.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp),
-        horizontalArrangement = Arrangement.spacedBy(24.dp)
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {
         if (historyViewModel.histories.isNotEmpty()) {
             itemsIndexed(historyViewModel.histories) { _, history ->

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/ToViewScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/ToViewScreen.kt
@@ -51,7 +51,7 @@ fun ToViewScreen(
         columns = GridCells.Fixed(4),
         contentPadding = PaddingValues(24.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp),
-        horizontalArrangement = Arrangement.spacedBy(24.dp)
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {
         // 未看完标题
         item(span = { GridItemSpan(maxLineSpan) }) {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/UpInfoScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/UpInfoScreen.kt
@@ -96,7 +96,7 @@ fun UpSpaceScreen(
                         fontSize = 24.sp
                     )
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(2.dp)
                     ) {
                         Text(
                             text = stringResource(
@@ -122,7 +122,7 @@ fun UpSpaceScreen(
             state = gridState,
             contentPadding = PaddingValues(24.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
-            horizontalArrangement = Arrangement.spacedBy(24.dp)
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             if (upInfoViewModel.spaceVideos.isNotEmpty()) {
                 itemsIndexed(

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/UserSwitchScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/UserSwitchScreen.kt
@@ -240,7 +240,7 @@ private fun UserSwitchContent(
 
             LazyRow(
                 modifier = Modifier.focusRequester(focusRequester),
-                horizontalArrangement = Arrangement.spacedBy(24.dp),
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
                 contentPadding = PaddingValues(horizontal = 12.dp)
             ) {
                 items(items = userList) { user ->
@@ -275,7 +275,7 @@ private fun UserSwitchContent(
             ) {
                 if (isInManagerMode) {
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(2.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(
@@ -286,7 +286,7 @@ private fun UserSwitchContent(
                     }
                 } else {
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(2.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(imageVector = Icons.Default.Settings, contentDescription = null)

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/lock/UnlockSwitchUserContent.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/lock/UnlockSwitchUserContent.kt
@@ -127,7 +127,7 @@ fun UnlockSwitchUserContent(
             }
 
             LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(24.dp),
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
                 contentPadding = PaddingValues(horizontal = 12.dp)
             ) {
                 items(items = userList) { user ->

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/lock/UnlockUserScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/lock/UnlockUserScreen.kt
@@ -185,7 +185,7 @@ private fun UnlockUserContent(
 
             LazyRow(
                 modifier = Modifier.focusRequester(defaultFocusRequester),
-                horizontalArrangement = Arrangement.spacedBy(24.dp),
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
                 contentPadding = PaddingValues(horizontal = 12.dp)
             ) {
                 items(items = userList) { user ->

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/lock/UserLockSettingsScreen.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/user/lock/UserLockSettingsScreen.kt
@@ -210,7 +210,7 @@ private fun UserLockSettingsContent(
 
             LazyRow(
                 modifier = Modifier.focusRequester(focusRequester),
-                horizontalArrangement = Arrangement.spacedBy(24.dp),
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
                 contentPadding = PaddingValues(horizontal = 12.dp)
             ) {
                 item {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/ui/theme/Theme.kt
@@ -39,7 +39,7 @@ fun BVTheme(
     val view = LocalView.current
 
     val colorSchemeTv = darkColorScheme(
-        border = Color.White
+        border = Color(0xFFFF69B4)
     )
     val colorSchemeCommon = androidx.compose.material3.darkColorScheme()
     val typographyTv =

--- a/app/src/main/kotlin/dev/aaa1115910/bv/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/ui/theme/Theme.kt
@@ -38,8 +38,11 @@ fun BVTheme(
     val fontScale = LocalDensity.current.fontScale
     val view = LocalView.current
 
+    val pink = Color(0xFFFF69B4)
     val colorSchemeTv = darkColorScheme(
-        border = Color(0xFFFF69B4)
+        border = pink,
+        inverseSurface = pink,
+        inverseOnSurface = Color.Black
     )
     val colorSchemeCommon = androidx.compose.material3.darkColorScheme()
     val typographyTv =

--- a/app/src/main/kotlin/dev/aaa1115910/bv/util/ModifierExtends.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/util/ModifierExtends.kt
@@ -2,12 +2,6 @@ package dev.aaa1115910.bv.util
 
 import android.graphics.Bitmap
 import android.graphics.Canvas
-import androidx.compose.animation.animateColor
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.border
 import androidx.compose.material3.ShapeDefaults
 import androidx.compose.runtime.getValue
@@ -41,23 +35,9 @@ fun Modifier.focusedBorder(
     shape: Shape = ShapeDefaults.Large,
     animate: Boolean = false
 ): Modifier = composed {
-    val infiniteTransition = rememberInfiniteTransition(label = "infinite border color transition")
     var hasFocus by remember { mutableStateOf(false) }
-
     val pink = Color(0xFFFF69B4)
-    val animateColor by infiniteTransition.animateColor(
-        initialValue = pink.copy(alpha = 1f),
-        targetValue = pink.copy(alpha = 0.1f),
-        animationSpec = infiniteRepeatable(
-            animation = tween(1000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "focused border animate color"
-    )
-    val focusColor = Color(0xFFFF69B4)
-    val borderColor = if (hasFocus) {
-        if (animate) animateColor else focusColor
-    } else Color.Transparent
+    val borderColor = if (hasFocus) pink else Color.Transparent
 
     onFocusChanged { hasFocus = it.hasFocus }
         .border(

--- a/app/src/main/kotlin/dev/aaa1115910/bv/util/ModifierExtends.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/util/ModifierExtends.kt
@@ -5,7 +5,6 @@ import android.graphics.Canvas
 import androidx.compose.animation.animateColor
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
@@ -18,7 +17,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -46,17 +44,19 @@ fun Modifier.focusedBorder(
     val infiniteTransition = rememberInfiniteTransition(label = "infinite border color transition")
     var hasFocus by remember { mutableStateOf(false) }
 
+    val pink = Color(0xFFFF69B4)
     val animateColor by infiniteTransition.animateColor(
-        initialValue = Color.White.copy(alpha = 1f),
-        targetValue = Color.White.copy(alpha = 0.1f),
+        initialValue = pink.copy(alpha = 1f),
+        targetValue = pink.copy(alpha = 0.1f),
         animationSpec = infiniteRepeatable(
             animation = tween(1000, easing = LinearEasing),
             repeatMode = RepeatMode.Reverse
         ),
         label = "focused border animate color"
     )
+    val focusColor = Color(0xFFFF69B4)
     val borderColor = if (hasFocus) {
-        if (animate) animateColor else Color.White
+        if (animate) animateColor else focusColor
     } else Color.Transparent
 
     onFocusChanged { hasFocus = it.hasFocus }
@@ -68,20 +68,12 @@ fun Modifier.focusedBorder(
 }
 
 /**
- * 在没有获取到焦点的时候缩小，以便在获取到焦点的时候“放大”
+ * 在没有获取到焦点的时候缩小，以便在获取到焦点的时候”放大”
+ * 已禁用缩放动画以提升性能，仅保留接口兼容
  */
 fun Modifier.focusedScale(
     scale: Float = 0.9f
-): Modifier = composed {
-    var hasFocus by remember { mutableStateOf(false) }
-    val scaleValue by animateFloatAsState(
-        targetValue = if (hasFocus) 1f else scale,
-        label = "focused scale"
-    )
-
-    onFocusChanged { hasFocus = it.hasFocus }
-        .scale(scaleValue)
-}
+): Modifier = this
 
 fun Modifier.bitmapMask(
     bitmap: Bitmap,

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/user/HistoryViewModel.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/user/HistoryViewModel.kt
@@ -16,6 +16,7 @@ import dev.aaa1115910.bv.entity.carddata.VideoCardData
 import dev.aaa1115910.bv.repository.UserRepository
 import dev.aaa1115910.bv.util.Prefs
 import dev.aaa1115910.bv.util.addWithMainContext
+import dev.aaa1115910.biliapi.http.util.toSmartDate
 import dev.aaa1115910.bv.util.fInfo
 import dev.aaa1115910.bv.util.fWarn
 import dev.aaa1115910.bv.util.formatHourMinSec
@@ -82,7 +83,8 @@ class HistoryViewModel(
                             R.string.play_time_history,
                             (historyItem.progress * 1000L).formatHourMinSec(),
                             (historyItem.duration * 1000L).formatHourMinSec()
-                        )
+                        ),
+                        pubTime = historyItem.viewAt.toSmartDate()
                     )
                 )
             }

--- a/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/entity/user/History.kt
+++ b/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/entity/user/History.kt
@@ -38,7 +38,8 @@ data class HistoryItem(
     val mid: Long?,
     val duration: Int,
     val progress: Int,
-    val type: HistoryItemType
+    val type: HistoryItemType,
+    val viewAt: Long = 0
 ) {
     companion object {
         fun fromHistoryItem(item: dev.aaa1115910.biliapi.http.entity.history.HistoryItem) =
@@ -59,7 +60,8 @@ data class HistoryItem(
                     "archive" -> HistoryItemType.Archive
                     "pgc" -> HistoryItemType.Pgc
                     else -> HistoryItemType.Unknown
-                }
+                },
+                viewAt = item.viewAt.toLong()
             )
 
         @Suppress("RemoveRedundantQualifierName")
@@ -111,7 +113,8 @@ data class HistoryItem(
                 CursorItem.CardItemCase.CARD_UGC -> HistoryItemType.Archive
                 CursorItem.CardItemCase.CARD_OGV -> HistoryItemType.Pgc
                 else -> HistoryItemType.Unknown
-            }
+            },
+            viewAt = item.viewAt
         )
     }
 }

--- a/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/repositories/SearchRepository.kt
+++ b/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/repositories/SearchRepository.kt
@@ -345,7 +345,8 @@ data class SearchTypeResult(
                     mid = video.av.mid,
                     duration = convertStringTimeToSeconds(video.av.duration),
                     play = video.av.play,
-                    danmaku = video.av.danmaku
+                    danmaku = video.av.danmaku,
+                    pubTime = video.av.showCardDesc2.ifEmpty { null }
                 )
         }
     }

--- a/bv-player/build.gradle.kts
+++ b/bv-player/build.gradle.kts
@@ -43,8 +43,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     buildFeatures {
         compose = true
@@ -54,7 +54,7 @@ android {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 


### PR DESCRIPTION
我这个PR是再你的R853上面改得 我看了一下 基本没有conflict 因为大部分都是UI简化

- 完全去掉所有video card/tag/详情页面得scale效果， 改掉了底层scale0.95f->1f得默认动画 现在静态为1f
- 改掉的focus video cards上得效果 改成了半透明背景focus 减少了video card之间得间距
- 搜索视频现在会加上视频上传时间再up主右侧
- 完全重作了左边导航栏和动画效果，变得更窄了
- 播放器使用逻辑修改， 暂停图片居中，按下暂停的时候 播放器也会自动取消隐藏
- 优化了资源使用 所有focus颜色改成了粉色
- 升级java到21

可以去掉claude.md 无伤大雅.

预览图
video card focus，左边栏
![4b3dba7a0cc6c43cdb490cf212e90137](https://github.com/user-attachments/assets/7a18ded3-1157-46f4-aeb2-c615f08a41e7)
完全去除tag得动画效果 fillin改成粉色
![9975b7bd45159bf214360373bf2baa7f](https://github.com/user-attachments/assets/36efd155-be6c-40a5-a4b0-13cf5169fd7e)
播放器暂停逻辑修改
![b6fa63e2d1ad1e3502b8526852e0ec18](https://github.com/user-attachments/assets/9267c2f2-1730-4c0c-b0b3-1a0a30035e3d)
搜索video cards会显示上传时间
![a1a84f8c90a0a8e18258a03833d8bceb](https://github.com/user-attachments/assets/d0d19644-7180-42cb-8678-9e875805c2ca)

完全自己用 设备的是shield pro默认UI十分的卡 而且不定时会崩溃 毫无必要的动画效果太多 基本全删掉了

PS: 期待你的下个版本 我会rebase上去 但是如果可以直接并入你的主干 我就不用自己rebase了