### PR TITLE
修正了web后端不能访问详情页面的bug

### DIFF
--- a/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/entity/ugc/UgcItem.kt
+++ b/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/entity/ugc/UgcItem.kt
@@ -46,7 +46,9 @@ data class UgcItem(
                         }
                     }.getOrDefault(-1)
                 },
-                duration = rcmdItem.coverRightText?.convertStringTimeToSeconds() ?: 0,
+                duration = rcmdItem.playerArgs?.duration
+                    ?: rcmdItem.coverRightText?.convertStringTimeToSeconds()
+                    ?: 0,
                 idx = rcmdItem.idx
             )
 

--- a/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/http/BiliHttpApi.kt
+++ b/bili-api/src/main/kotlin/dev/aaa1115910/biliapi/http/BiliHttpApi.kt
@@ -183,7 +183,7 @@ object BiliHttpApi {
         av: Long? = null,
         bv: String? = null,
         sessData: String? = null
-    ): BiliResponse<VideoDetail> = client.get("/x/web-interface/view/detail") {
+    ): BiliResponse<VideoDetail> = client.get("/x/web-interface/wbi/view/detail") {
         parameter("aid", av)
         parameter("bvid", bv)
         sessData?.let { header("Cookie", "SESSDATA=$sessData;") }


### PR DESCRIPTION
- Switch getVideoDetail to WBI-signed endpoint (/x/web-interface/wbi/view/detail) so it passes bilibili's new risk-control checks when using web backend
- Fix 推荐 card timestamps for App backend: prefer playerArgs.duration (exact int) over coverRightText (string that may be null) in UgcItem.fromRcmdItem